### PR TITLE
On unexpected error log exception message

### DIFF
--- a/src/DBDiff.php
+++ b/src/DBDiff.php
@@ -49,7 +49,7 @@ class DBDiff {
             if ($e instanceof BaseException) {
                 Logger::error($e->getMessage(), true);
             } else {
-                Logger::error("Unexpected error: ");
+                Logger::error("Unexpected error: " . $e->getMessage());
                 throw $e;
             }
         }


### PR DESCRIPTION
When an unexcepted error occours the following message below is logged, without further information.

✖ Unexpected error:

With this change the exception thrown message is appended to provide more detailed information.