### PR TITLE
Wrap table names with backticks

### DIFF
--- a/src/DB/DBManager.php
+++ b/src/DB/DBManager.php
@@ -58,12 +58,12 @@ class DBManager {
     }
 
     public function getColumns($connection, $table) {
-        $result = $this->getDB($connection)->select("show columns from $table");
+        $result = $this->getDB($connection)->select("show columns from `$table`");
         return array_pluck($result, 'Field');
     }
 
     public function getKey($connection, $table) {
-        $keys = $this->getDB($connection)->select("show indexes from $table");
+        $keys = $this->getDB($connection)->select("show indexes from `$table`");
         $ukey = [];
         foreach ($keys as $key) {
             if ($key['Key_name'] === 'PRIMARY') {


### PR DESCRIPTION
Wrap table names with backticks to prevent conflicting table names with mysql-reserved words