### PR TITLE
Foreign key change tries to drop empty named constraint

### DIFF
--- a/src/SQLGen/DiffToSQL/AlterTableChangeConstraintSQL.php
+++ b/src/SQLGen/DiffToSQL/AlterTableChangeConstraintSQL.php
@@ -13,14 +13,14 @@ class AlterTableChangeConstraintSQL implements SQLGenInterface {
         $table = $this->obj->table;
         $name = $this->obj->name;
         $schema = $this->obj->diff->getNewValue();
-        return "ALTER TABLE `$table` DROP CONSTRAINT `$key`;\nALTER TABLE `$table` ADD $schema;";
+        return "ALTER TABLE `$table` DROP CONSTRAINT `$name`;\nALTER TABLE `$table` ADD $schema;";
     }
 
     public function getDown() {
         $table = $this->obj->table;
         $name = $this->obj->name;
         $schema = $this->obj->diff->getOldValue();
-        return "ALTER TABLE `$table` DROP CONSTRAINT `$key`;\nALTER TABLE `$table` ADD $schema;";
+        return "ALTER TABLE `$table` DROP CONSTRAINT `$name`;\nALTER TABLE `$table` ADD $schema;";
     }
 
 }


### PR DESCRIPTION
When DBDiff finds it needs to change a foreign key, it will create two statements, a drop and a add. The add is fine, but the drop is created without a name. 

It will show up as ```ALTER TABLE `sometable` DROP CONSTRAINT ``;```. This patch should fix the problem;

