### PR TITLE
If port is not set on server, it would show a PHP warning 

### DIFF
--- a/src/Params/CLIGetter.php
+++ b/src/Params/CLIGetter.php
@@ -56,8 +56,8 @@ class CLIGetter implements ParamsGetter {
         return [
             'user'     => $creds[0],
             'password' => $creds[1],
-            'host'     => $dns[0],
-            'port'     => $dns[1]
+            'host'     => array_shift($dns),
+            'port'     => array_shift($dns)
         ];
     }
 


### PR DESCRIPTION
When running the command like this:

``` 
dbdiff --type=schema --server1=user1:pass1@server1.com ...
```

It would throw a PHP warning:

PHP Notice:  Undefined offset: 1 in /var/www/DBDiff/src/Params/CLIGetter.php on line 60
PHP Stack trace:
PHP   1. {main}() /var/www/DBDiff/dbdiff:0
PHP   2. DBDiff\DBDiff->run() /var/www/DBDiff/dbdiff:8
PHP   3. DBDiff\Params\ParamsFactory::get() /var/www/DBDiff/src/DBDiff.php:19
PHP   4. DBDiff\Params\CLIGetter->getParams() /var/www/DBDiff/src/Params/ParamsFactory.php:13
PHP   5. DBDiff\Params\CLIGetter->parseServer() /var/www/DBDiff/src/Params/CLIGetter.php:31

Notice: Undefined offset: 1 in /var/www/DBDiff/src/Params/CLIGetter.php on line 60

Call Stack:
    0.0004     221848   1. {main}() /var/www/DBDiff/dbdiff:0
    0.0642     884144   2. DBDiff\DBDiff->run() /var/www/DBDiff/dbdiff:8
    0.0662     892920   3. DBDiff\Params\ParamsFactory::get() /var/www/DBDiff/src/DBDiff.php:19
    0.0702     930520   4. DBDiff\Params\CLIGetter->getParams() /var/www/DBDiff/src/Params/ParamsFactory.php:13
    0.1079    1202096   5. DBDiff\Params\CLIGetter->parseServer() /var/www/DBDiff/src/Params/CLIGetter.php:31

