### PR TITLE
Phar + composer global require

### DIFF
--- a/build
+++ b/build
@@ -1,0 +1,25 @@
+#!/usr/bin/env php
+<?php
+
+$dir = __DIR__ . '/dist';
+$file = $dir . '/dbdiff.phar';
+
+@unlink($file);
+@mkdir($dir, 0755, true);
+
+$phar = new Phar($file);
+
+$phar->startBuffering();
+
+$phar->buildFromDirectory(__DIR__, '/src\/.*|vendor\/.*|dbdiff\.php/');
+
+$stub = $phar->createDefaultStub('dbdiff.php');
+$stub = "#!/usr/bin/env php \n" . $stub;
+$phar->setStub($stub);
+
+$phar->compressFiles(Phar::GZ);
+$phar->stopBuffering();
+
+chmod($file, 0755);
+
+echo 'Build successful: dist/dbdiff.phar' . PHP_EOL;

--- a/dbdiff
+++ b/dbdiff
@@ -1,8 +1,11 @@
 #!/usr/bin/env php
 <?php
 
-require 'vendor/autoload.php';
-
+if (file_exists(__DIR__ . '/../../autoload.php')) {
+    require __DIR__ . '/../../autoload.php';
+} else {
+    require __DIR__ . '/vendor/autoload.php';
+}
 
 $dbdiff = new DBDiff\DBDiff;
 $dbdiff->run();

--- a/dbdiff.php
+++ b/dbdiff.php
@@ -1,0 +1,6 @@
+<?php
+
+require __DIR__ . '/vendor/autoload.php';
+
+$dbdiff = new DBDiff\DBDiff;
+$dbdiff->run();

--- a/src/Params/FSGetter.php
+++ b/src/Params/FSGetter.php
@@ -37,8 +37,8 @@ class FSGetter implements ParamsGetter {
                 throw new FSException("Config file not found");
             }
         } else {
-            if (file_exists('.dbdiff')) {
-                $configFile = '.dbdiff';
+            if (file_exists(getcwd() . '/.dbdiff')) {
+                $configFile = getcwd() . '/.dbdiff';
             }
         }
 


### PR DESCRIPTION
Put into practice changes described here: https://github.com/DBDiff/DBDiff/issues/73

Now we can simply install DBDiff globally using:
```
composer global require "dbdiff/dbdiff:@dev"
```

Or we can build a Phar:  
1. Clone the repository;
2. ```composer install```
3. ```./build```
4. Find a Phar in dist folder
5. You can rename "dbdiff.phar" to "dbdiff" and move it to /usr/local/bin, for example.
