### PR TITLE
fix(SQL): Escape Database Names

### DIFF
--- a/src/DB/Data/LocalTableData.php
+++ b/src/DB/Data/LocalTableData.php
@@ -57,12 +57,12 @@ class LocalTableData {
 
         $this->source->setFetchMode(\PDO::FETCH_NAMED);
         $result1 = $this->source->select(
-           "SELECT $columnsAUtf FROM {$db1}.{$table} as a
-            LEFT JOIN {$db2}.{$table} as b ON $keyCols WHERE $keyNulls2
+           "SELECT $columnsAUtf FROM `{$db1}`.`{$table}` as a
+            LEFT JOIN `{$db2}`.`{$table}` as b ON $keyCols WHERE $keyNulls2
         ");
         $result2 = $this->source->select(
-           "SELECT $columnsBUtf FROM {$db2}.{$table} as b
-            LEFT JOIN {$db1}.{$table} as a ON $keyCols WHERE $keyNulls1
+           "SELECT $columnsBUtf FROM `{$db2}`.`{$table}` as b
+            LEFT JOIN `{$db1}`.`{$table}` as a ON $keyCols WHERE $keyNulls1
         ");
         $this->source->setFetchMode(\PDO::FETCH_ASSOC);
 
@@ -123,8 +123,8 @@ class LocalTableData {
         $result = $this->source->select(
            "SELECT * FROM (
                 SELECT $columnsAas, $columnsBas, MD5(concat($columnsA)) AS hash1,
-                MD5(concat($columnsB)) AS hash2 FROM {$db1}.{$table} as a 
-                INNER JOIN {$db2}.{$table} as b  
+                MD5(concat($columnsB)) AS hash2 FROM `{$db1}`.`{$table}` as a 
+                INNER JOIN `{$db2}`.`{$table}` as b  
                 ON $keyCols
             ) t WHERE hash1 <> hash2");
         $this->source->setFetchMode(\PDO::FETCH_ASSOC);


### PR DESCRIPTION
Like with DBDiff#14 wrap database- and table names with Backticks to prevent conflicting with mysql-reserved keys