### PR TITLE
Fixed calling undefined methods when columns added or removed

### DIFF
--- a/src/SQLGen/DiffToSQL/UpdateDataSQL.php
+++ b/src/SQLGen/DiffToSQL/UpdateDataSQL.php
@@ -14,7 +14,7 @@ class UpdateDataSQL implements SQLGenInterface {
         
         $values = $this->obj->diff['diff'];
         array_walk($values, function(&$diff, $column) {
-            if(!is_null($diff->getNewValue())) {
+            if(method_exists($diff, 'getNewValue') && !is_null($diff->getNewValue())) {
                 $diff = '`' . $column . "` = '" . addslashes($diff->getNewValue()) . "'";
             }
             else {
@@ -37,7 +37,12 @@ class UpdateDataSQL implements SQLGenInterface {
         
         $values = $this->obj->diff['diff'];
         array_walk($values, function(&$diff, $column) {
-            $diff = '`'.$column."` = '".addslashes($diff->getOldValue())."'";
+            if(method_exists($diff, 'getOldValue') && !is_null($diff->getOldValue())) {
+                $diff = '`'.$column."` = '".addslashes($diff->getOldValue())."'";
+            }
+            else {
+                $diff = '`' . $column . "` = NULL";
+            }
         });
         $values = implode(', ', $values);
 


### PR DESCRIPTION
When GetOldValue or GetNewValue are not defined, do not try and call methods, just treat as NULL.

This can happen when columns only exist in one of the tables being compared.