### PR TITLE
Mark `merge` as static to match usage

### DIFF
--- a/src/Params/ParamsFactory.php
+++ b/src/Params/ParamsFactory.php
@@ -29,7 +29,7 @@ class ParamsFactory {
 
     }
 
-    protected function merge($obj1, $obj2) {
+    static protected function merge($obj1, $obj2) {
         return (object) array_merge((array) $obj1, (array) $obj2);
     }
 }


### PR DESCRIPTION
`ParamsFactory::merge` is called as if it's a static function, but it wasn't marked as static