### PR TITLE
fix(release): use correct micro.sfx filename on Windows

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -215,7 +215,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $phpBytes  = [IO.File]::ReadAllBytes("buildroot\bin\micro.sfx.exe")
+          $phpBytes  = [IO.File]::ReadAllBytes("buildroot\bin\micro.sfx")
           $pharBytes = [IO.File]::ReadAllBytes("dist\dbdiff.phar")
           [IO.File]::WriteAllBytes("dbdiff.exe", $phpBytes + $pharBytes)
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,7 +231,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $phpBytes  = [IO.File]::ReadAllBytes("buildroot\bin\micro.sfx.exe")
+          $phpBytes  = [IO.File]::ReadAllBytes("buildroot\bin\micro.sfx")
           $pharBytes = [IO.File]::ReadAllBytes("dist\dbdiff.phar")
           [IO.File]::WriteAllBytes("dbdiff.exe", $phpBytes + $pharBytes)
 


### PR DESCRIPTION
## fix(release): correct `micro.sfx` filename on Windows

### Problem

The "Combine PHP + PHAR → binary (Windows)" step failed with:

    Could not find file 'D:\a\DBDiff\DBDiff\buildroot\bin\micro.sfx.exe'

### Root cause

SPC's `WindowsBuilder::deploySAPIBinary()` copies the built micro SAPI to
`buildroot\bin\micro.sfx` on **all** platforms — the filename has no `.exe`
extension, even on Windows. Both `release.yml` and `release-dry-run.yml`
incorrectly referenced `micro.sfx.exe`.

Confirmed by the [SPC docs](https://static-php.dev/en/guide/manual-build.html):
> "micro: The build result is `buildroot/bin/micro.sfx`"

And by [`WindowsBuilder.php`](https://github.com/crazywhalecc/static-php-cli/blob/main/src/SPC/builder/windows/WindowsBuilder.php) — `deploySAPIBinary()` deploys `micro.sfx` (no `.exe`) regardless of platform.

### Fix

Changed `buildroot\bin\micro.sfx.exe` → `buildroot\bin\micro.sfx` in the
Windows combine step of both workflows.

### Files changed

- `.github/workflows/release.yml`
- `.github/workflows/release-dry-run.yml`