### PR TITLE
ci(release): stop a partial binary matrix from publishing a release (#185)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,10 +113,14 @@ jobs:
             musl:     false
             artifact: dbdiff-linux-arm64
 
-          # ── Linux musl (Alpine) ───────────────────────────────────────────
-          # The build runs inside an Alpine Docker container so the resulting
-          # binary is musl-linked.  The host OS still needs to be the right
-          # architecture so that `docker run alpine` uses the correct image.
+          # ── Linux musl ────────────────────────────────────────────────────
+          # NOTE: these legs currently build on the ubuntu host exactly like the
+          # glibc ones — the `musl` flag below is not referenced by any step, and
+          # no Alpine container is used. SPC links everything against its own
+          # musl toolchain anyway (see the note above the SPC download step), so
+          # the resulting binaries are byte-identical to the glibc ones today.
+          # Building these inside Alpine would let `spc doctor` skip the
+          # musl-wrapper install entirely; tracked in #185.
           - target:   linux-x64-musl
             os:       ubuntu-latest
             musl:     true
@@ -193,7 +197,24 @@ jobs:
           # calls before the spc download step runs.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ./spc doctor --auto-fix
+          # `spc doctor --auto-fix` installs the musl cross-compiler by fetching
+          # musl source from musl.libc.org — a single lightly-provisioned origin
+          # with no CDN, and spc performs no retry of its own. A connection
+          # timeout there (curl exit 28, after ~134s) killed three Linux legs of
+          # the v3.0.0-rc.5 release and shipped a partial package set. See #185.
+          # Retry with backoff so one transient timeout does not fail the leg.
+          for attempt in 1 2 3; do
+            if ./spc doctor --auto-fix; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::spc doctor --auto-fix failed after 3 attempts"
+              exit 1
+            fi
+            backoff=$((attempt * 30))
+            echo "spc doctor attempt ${attempt} failed — retrying in ${backoff}s ..."
+            sleep "$backoff"
+          done
           ./spc download \
             "php-src,micro,${{ env.SPC_EXTENSIONS }},${{ env.SPC_LIBS }}" \
             --with-php="${{ env.SPC_PHP_VERSION }}"
@@ -269,7 +290,11 @@ jobs:
   github-release:
     name: GitHub Release
     needs: [build-phar, build-binary]
-    if: ${{ !cancelled() && needs.build-phar.result == 'success' }}
+    # Must check build-binary too. The matrix runs with fail-fast: false so that
+    # one broken target does not cancel the rest, which means a partial build
+    # completes "successfully" from the workflow's point of view. Gating only on
+    # build-phar published v3.0.0-rc.5 with three platforms missing (#185).
+    if: ${{ !cancelled() && needs.build-phar.result == 'success' && needs.build-binary.result == 'success' }}
     runs-on: ubuntu-latest
 
     permissions:
@@ -350,7 +375,9 @@ jobs:
   publish-npm:
     name: Publish npm packages
     needs: [build-phar, build-binary, github-release]
-    if: ${{ !cancelled() && needs.build-phar.result == 'success' }}
+    # See the note on github-release above — build-binary must be checked here
+    # too, or a partially built matrix still reaches the registries.
+    if: ${{ !cancelled() && needs.build-phar.result == 'success' && needs.build-binary.result == 'success' }}
     runs-on: ubuntu-latest
 
     permissions:
@@ -418,6 +445,37 @@ jobs:
           copy_binary binaries/dbdiff-darwin-arm64/dbdiff        packages/@dbdiff/cli-darwin-arm64/dbdiff
           copy_binary binaries/dbdiff-win32-x64/dbdiff.exe       packages/@dbdiff/cli-win32-x64/dbdiff.exe
           chmod +x packages/@dbdiff/cli-*/dbdiff || true
+
+      # Last line of defence before anything reaches a registry. The job gate
+      # already requires build-binary to have succeeded, but an artifact that
+      # failed to download would still slip through as a silently missing
+      # platform — which is exactly how v3.0.0-rc.5 shipped without linux-x64
+      # (#185). The copy step above only emits a ::warning:: in that case.
+      - name: Verify every platform package has its binary
+        run: |
+          # @dbdiff/cli-win32-arm64 is intentionally binary-less: SPC cannot
+          # build that target (see the matrix comment), so it ships as a
+          # PHAR-fallback skeleton and is exempt from this check.
+          PHAR_FALLBACK_PKGS="@dbdiff/cli-win32-arm64"
+          missing=""
+          for pkg_dir in packages/@dbdiff/cli-*/; do
+            pkg_name=$(node -e "console.log(require('./${pkg_dir}package.json').name)")
+            if echo "$PHAR_FALLBACK_PKGS" | grep -qw "$pkg_name"; then
+              echo "  ${pkg_name} — PHAR fallback, no binary expected"
+              continue
+            fi
+            if [ -f "${pkg_dir}dbdiff" ] || [ -f "${pkg_dir}dbdiff.exe" ]; then
+              echo "  ${pkg_name} — ok"
+            else
+              echo "::error::${pkg_name} has no binary"
+              missing="${missing} ${pkg_name}"
+            fi
+          done
+          if [ -n "$missing" ]; then
+            echo "::error::Refusing to publish a partial release. Missing binaries for:${missing}"
+            exit 1
+          fi
+          echo "All platform packages have a binary."
 
       - name: Bundle PHAR into @dbdiff/cli for PHP fallback
         run: cp binaries/dbdiff-phar/dbdiff.phar packages/@dbdiff/cli/dbdiff.phar


### PR DESCRIPTION
Fixes #185.

`v3.0.0-rc.5` shipped to npm without `linux-x64`, `linux-x64-musl` or `linux-arm64-musl`. Three separate things had to line up for that to happen, and this fixes all three.

## 1. The publish jobs never looked at the binary matrix

The matrix runs with `fail-fast: false` so one broken target does not cancel the rest — which means a partial build looks fine to anything that does not explicitly inspect it. The gate was:

```yaml
if: ${{ !cancelled() && needs.build-phar.result == 'success' }}
```

`needs.build-binary.result` is never consulted, so three failed legs did not stop the release. Now checked on both jobs.

**This applied to `github-release` as well, not just `publish-npm`** — the issue comment identified the `publish-npm` line, but `github-release` carries the identical condition and cut a release from an incomplete asset set for the same reason. Fixing only one would have left the Release page still publishable from a partial build.

## 2. `spc doctor` had no retry on a flaky download

All three legs died in the same place. `spc doctor --auto-fix` fetches musl source from `musl.libc.org` to build the cross-compiler, and that host is a single lightly-provisioned origin with no CDN. `curl` timed out after ~134s (exit 28); spc performs no retry of its own.

I reproduced this locally with the same pinned spc 2.8.3 on linux-x64:

```
Checking if musl-wrapper is installed ... musl-wrapper is not installed on your system
Automatically fixing fix-musl-wrapper ...
Downloading https://musl.libc.org/releases/musl-1.2.5.tar.gz
Fix failed: Download failed
```

Worth noting *why* the glibc legs need this at all: spc always links against its own musl toolchain on Linux so the binaries come out fully static, which is why `linux-x64` failed alongside the two musl targets. `linux-arm64` survived on the same runner family in the same minute, which points at transient flakiness rather than a toolchain break — so three attempts with 30s/60s backoff should cover it.

I also checked the obvious alternative and it does **not** work: installing `musl`/`musl-dev`/`musl-tools` from apt leaves `musl-gcc` at `/usr/bin/musl-gcc`, and spc still reports `musl-wrapper is not installed`. Symlinking it to `/usr/local/musl/bin/musl-gcc` did not satisfy the check either — spc wants its own build.

## 3. A missing binary only produced a warning

The job gate is the real fix, but `Copy binaries into platform packages` emits only a `::warning::` when an artifact is absent, so a failed *download* (as opposed to a failed build) would still yield a silently partial publish. A verification step now fails the job and names what is missing.

`@dbdiff/cli-win32-arm64` is exempt — spc cannot build that target, so it ships as a PHAR-fallback skeleton by design.

Tested against both states. The exact rc.5 artifact set:

```
  @dbdiff/cli-darwin-arm64 — ok
  @dbdiff/cli-darwin-x64 — ok
::error::@dbdiff/cli-linux-arm64-musl has no binary
  @dbdiff/cli-linux-arm64 — ok
::error::@dbdiff/cli-linux-x64-musl has no binary
::error::@dbdiff/cli-linux-x64 has no binary
  @dbdiff/cli-win32-arm64 — PHAR fallback, no binary expected
  @dbdiff/cli-win32-x64 — ok
::error::Refusing to publish a partial release. Missing binaries for: …
EXIT=1
```

and a complete one — all eight accounted for, `EXIT=0`. The retry loop was exercised on all three paths (succeeds first try, succeeds on the third, never succeeds).

## Also

Corrects the Linux musl matrix comment, which described an Alpine container build that does not exist — `matrix.musl` is not referenced by any step, so those legs build on the ubuntu host exactly like the glibc ones. Building them inside Alpine would let `spc doctor` skip the musl-wrapper install altogether; that is worth doing but is a larger change, so it stays tracked in #185 rather than being attempted here.

## Not included

Caching `/usr/local/musl` via `actions/cache`, which would take the download off the hot path permanently. I could not confirm the install prefix from the stripped spc binary, and I would rather key a cache on a verified path than a guessed one — worth adding once a green run confirms it.

## Re-running the rc.5 release

Since this comes up immediately: the pipeline is **partly** idempotent, and the answer differs per target.

- **npm (both registries) — safe.** Each package is guarded by `npm view "${pkg_name}@${VERSION}"` and skipped if already present, so a re-run publishes only the three missing packages and cannot clobber the five that exist.
- **Git tag — safe.** `Create git tag` explicitly skips when the tag already exists on origin.
- **GitHub Release — not idempotent.** `softprops/action-gh-release@v2` runs with `generate_release_notes: true`, so a re-run **regenerates the release body**. Any hand-editing of the rc.5 notes would be overwritten, and assets are re-uploaded.
- **Docker — overwrites.** `publish-docker` needs only `build-phar` and re-pushes the same GHCR tags.

One trap worth flagging: GitHub's **"Re-run failed jobs"** will rebuild the three binary legs but will *not* re-run `github-release` or `publish-npm`, because those succeeded — so the newly built binaries would never be published. A full re-run of the workflow is needed, which also rebuilds the four already-good targets (6–18 min each).

Given the release-notes clobbering, cutting `rc.6` from this branch once merged is the cleaner path than re-running `rc.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)