### PR TITLE
fix(pgsql): key routines by signature so overloads survive the diff (#187)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,8 @@ MYSQL_VERSION_93=9.3
 MYSQL_VERSION_96=9.6
 
 # Dolt (MySQL-compatible, version-controlled database)
-DOLT_VERSION=latest
+# Pinned: 2.3.0 aborts DDL at random with "1105 context canceled".
+DOLT_VERSION=2.2.3
 
 # Individual PostgreSQL Versions
 POSTGRES_VERSION_14=14

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,7 +103,11 @@ jobs:
 
     services:
       dolt:
-        image: dolthub/dolt-sql-server:latest
+        # Pinned like every other DB service here. Dolt 2.3.0 (published
+        # 2026-08-13) aborts DDL mid-statement with "General error: 1105
+        # context canceled" at random, so `latest` broke CI on a day nobody
+        # touched the code. 2.2.3 is the last version this suite was green on.
+        image: dolthub/dolt-sql-server:2.2.3
         env:
           DOLT_ROOT_PASSWORD: rootpass
           DOLT_ROOT_HOST: "%"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -396,7 +396,7 @@ services:
 
   # Dolt (MySQL-compatible, version-controlled database)
   db-dolt:
-    image: docker.io/dolthub/dolt-sql-server:latest
+    image: docker.io/dolthub/dolt-sql-server:${DOLT_VERSION}
     restart: always
     ports:
       - '${DB_PORT_DOLT}:3306'

--- a/src/DB/Adapters/PostgresAdapter.php
+++ b/src/DB/Adapters/PostgresAdapter.php
@@ -138,24 +138,43 @@ class PostgresAdapter implements DBAdapterInterface, BulkSchemaAdapterInterface 
                AND n.nspname = 'public'
              ORDER BY t.tgname"
         );
+        // Keyed by table and name: trigger names are unique per table, not per
+        // schema, so two tables may legitimately share one. Keying on the name
+        // alone silently dropped all but the last (issue #187). The bare name
+        // is carried through so the emitted DDL is unaffected.
         $triggers = [];
         foreach ($result as $row) {
-            $triggers[$row['name']] = [
+            $triggers[$row['table_name'] . '.' . $row['name']] = [
                 'definition' => $row['definition'],
                 'table'      => $row['table_name'],
+                'name'       => $row['name'],
             ];
         }
         return $triggers;
     }
 
+    /**
+     * Routines keyed by signature, not bare name.
+     *
+     * Postgres allows overloads — several functions sharing a name with
+     * different argument types. Keying on proname made them overwrite each
+     * other, so N-1 overloads were invisible to the diff and which one
+     * survived depended on row order, which differs between databases. Two
+     * identical schemas could therefore report drift, and the generated
+     * migration dropped every overload to recreate one. See issue #187.
+     *
+     * regprocedure renders as `cosine_distance(integer,integer)` — unique per
+     * overload and stable across databases, unlike oid. Ordering by the same
+     * expression keeps output deterministic where proname left ties unordered.
+     */
     public function getRoutines(Connection $connection): array {
         $result = $connection->select(
-            "SELECT p.proname AS name, pg_get_functiondef(p.oid) AS definition
+            "SELECT p.oid::regprocedure::text AS name, pg_get_functiondef(p.oid) AS definition
              FROM pg_proc p
              JOIN pg_namespace n ON p.pronamespace = n.oid
              WHERE n.nspname = 'public'
                AND p.prokind IN ('f', 'p')
-             ORDER BY p.proname"
+             ORDER BY p.oid::regprocedure::text"
         );
         $routines = [];
         foreach ($result as $row) {

--- a/src/DB/Schema/DBSchema.php
+++ b/src/DB/Schema/DBSchema.php
@@ -217,16 +217,25 @@ class DBSchema {
         $targetTriggers = $this->manager->getTriggers('target');
         $diffs = [];
 
-        foreach (array_diff_key($sourceTriggers, $targetTriggers) as $name => $data) {
-            $diffs[] = new CreateTrigger($name, $data['table'], $data['definition']);
+        // Keys are "table.trigger" so same-named triggers on different tables
+        // stay distinct (issue #187); the emitted DDL uses the bare name the
+        // adapter carries alongside, falling back to the key for adapters that
+        // do not supply one.
+        foreach (array_diff_key($sourceTriggers, $targetTriggers) as $key => $data) {
+            $diffs[] = new CreateTrigger($data['name'] ?? $key, $data['table'], $data['definition']);
         }
-        foreach (array_diff_key($targetTriggers, $sourceTriggers) as $name => $data) {
-            $diffs[] = new DropTrigger($name, $data['table'], $data['definition']);
+        foreach (array_diff_key($targetTriggers, $sourceTriggers) as $key => $data) {
+            $diffs[] = new DropTrigger($data['name'] ?? $key, $data['table'], $data['definition']);
         }
-        foreach (array_intersect_key($sourceTriggers, $targetTriggers) as $name => $srcData) {
-            $tgtData = $targetTriggers[$name];
+        foreach (array_intersect_key($sourceTriggers, $targetTriggers) as $key => $srcData) {
+            $tgtData = $targetTriggers[$key];
             if ($srcData['definition'] !== $tgtData['definition']) {
-                $diffs[] = new AlterTrigger($name, $srcData['table'], $srcData['definition'], $tgtData['definition']);
+                $diffs[] = new AlterTrigger(
+                    $srcData['name'] ?? $key,
+                    $srcData['table'],
+                    $srcData['definition'],
+                    $tgtData['definition']
+                );
             }
         }
         return $diffs;

--- a/src/SQLGen/DiffToSQL/AlterRoutineSQL.php
+++ b/src/SQLGen/DiffToSQL/AlterRoutineSQL.php
@@ -16,20 +16,13 @@ class AlterRoutineSQL implements SQLGenInterface {
     }
 
     public function getUp(): string {
-        $drop = $this->buildDrop($this->obj->targetDefinition, $this->obj->name);
+        $drop = RoutineDrop::build($this->obj->targetDefinition, $this->obj->name, $this->dialect);
         return $drop . "\n" . $this->obj->sourceDefinition . ';';
     }
 
     public function getDown(): string {
-        $drop = $this->buildDrop($this->obj->sourceDefinition, $this->obj->name);
+        $drop = RoutineDrop::build($this->obj->sourceDefinition, $this->obj->name, $this->dialect);
         return $drop . "\n" . $this->obj->targetDefinition . ';';
     }
 
-    private function buildDrop(string $definition, string $name): string {
-        $type = 'FUNCTION';
-        if (preg_match('/\bPROCEDURE\b/i', $definition)) {
-            $type = 'PROCEDURE';
-        }
-        return "DROP $type IF EXISTS " . $this->dialect->quote($name) . ';';
-    }
 }

--- a/src/SQLGen/DiffToSQL/CreateRoutineSQL.php
+++ b/src/SQLGen/DiffToSQL/CreateRoutineSQL.php
@@ -20,17 +20,7 @@ class CreateRoutineSQL implements SQLGenInterface {
     }
 
     public function getDown(): string {
-        return $this->buildDrop($this->obj->definition, $this->obj->name);
+        return RoutineDrop::build($this->obj->definition, $this->obj->name, $this->dialect);
     }
 
-    /**
-     * Build a DROP statement that matches the routine type (PROCEDURE or FUNCTION).
-     */
-    private function buildDrop(string $definition, string $name): string {
-        $type = 'FUNCTION';
-        if (preg_match('/\bPROCEDURE\b/i', $definition)) {
-            $type = 'PROCEDURE';
-        }
-        return "DROP $type IF EXISTS " . $this->dialect->quote($name) . ';';
-    }
 }

--- a/src/SQLGen/DiffToSQL/DropRoutineSQL.php
+++ b/src/SQLGen/DiffToSQL/DropRoutineSQL.php
@@ -16,18 +16,11 @@ class DropRoutineSQL implements SQLGenInterface {
     }
 
     public function getUp(): string {
-        return $this->buildDrop($this->obj->definition, $this->obj->name);
+        return RoutineDrop::build($this->obj->definition, $this->obj->name, $this->dialect);
     }
 
     public function getDown(): string {
         return $this->obj->definition . ';';
     }
 
-    private function buildDrop(string $definition, string $name): string {
-        $type = 'FUNCTION';
-        if (preg_match('/\bPROCEDURE\b/i', $definition)) {
-            $type = 'PROCEDURE';
-        }
-        return "DROP $type IF EXISTS " . $this->dialect->quote($name) . ';';
-    }
 }

--- a/src/SQLGen/DiffToSQL/RoutineDrop.php
+++ b/src/SQLGen/DiffToSQL/RoutineDrop.php
@@ -1,0 +1,48 @@
+<?php namespace DBDiff\SQLGen\DiffToSQL;
+
+use DBDiff\SQLGen\Dialect\SQLDialectInterface;
+
+
+/**
+ * Builds the DROP statement that precedes a routine replacement.
+ *
+ * Shared by DropRoutineSQL and AlterRoutineSQL, which previously carried
+ * identical private copies — so the argument-list handling below would
+ * otherwise have had to be written twice.
+ */
+class RoutineDrop {
+
+    /**
+     * @param string $definition Routine DDL, used only to tell FUNCTION from PROCEDURE.
+     * @param string $name       Bare name, or a Postgres signature like `fn(integer,text)`.
+     */
+    public static function build(string $definition, string $name, SQLDialectInterface $dialect): string {
+        $type = preg_match('/\bPROCEDURE\b/i', $definition) ? 'PROCEDURE' : 'FUNCTION';
+        [$bare, $args] = self::splitSignature($name);
+        return "DROP $type IF EXISTS " . $dialect->quote($bare) . $args . ';';
+    }
+
+    /**
+     * Split `fn(integer,text)` into the name and its argument list.
+     *
+     * Postgres keys routines by signature so overloads stay distinct (issue
+     * #187), and an unqualified DROP is ambiguous once overloads exist:
+     *
+     *     ERROR: function name "cosine_distance" is not unique
+     *
+     * The argument list is appended outside the quoted identifier — quoting
+     * the whole signature would produce `"fn(integer,text)"`, a single odd
+     * identifier rather than a call signature.
+     *
+     * MySQL has no overloads and passes a bare name, which returns unchanged.
+     *
+     * @return array{string, string} [bare name, argument list including parens]
+     */
+    private static function splitSignature(string $name): array {
+        $pos = strpos($name, '(');
+        if ($pos === false) {
+            return [$name, ''];
+        }
+        return [substr($name, 0, $pos), substr($name, $pos)];
+    }
+}

--- a/tests/RoutineOverloadPostgresTest.php
+++ b/tests/RoutineOverloadPostgresTest.php
@@ -1,0 +1,157 @@
+<?php
+
+use DBDiff\DB\Adapters\PostgresAdapter;
+use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Database\Events\StatementPrepared;
+use Illuminate\Events\Dispatcher;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Live-server regression tests for issue #187.
+ *
+ * getRoutines() keyed its map on proname, so overloaded functions overwrote
+ * each other: N-1 overloads were invisible to the diff, and which one survived
+ * depended on row order — which differs between databases. Two identical
+ * schemas reported drift, and the migration dropped every overload.
+ *
+ * The same applied to triggers, whose names are unique per table, not per
+ * schema.
+ *
+ * Skips automatically without pdo_pgsql or DB_HOST_POSTGRES.
+ */
+class RoutineOverloadPostgresTest extends TestCase
+{
+    private string $db = 'dbdiff_overloads';
+    private ?PDO $adminDb = null;
+    private $capsule;
+    private $connection;
+    private PostgresAdapter $adapter;
+
+    protected function setUp(): void
+    {
+        if (!extension_loaded('pdo_pgsql')) {
+            $this->markTestSkipped('pdo_pgsql extension not loaded.');
+        }
+        $host = getenv('DB_HOST_POSTGRES') ?: null;
+        if (!$host) {
+            $this->markTestSkipped('DB_HOST_POSTGRES env var not set.');
+        }
+
+        $this->adminDb = new PDO(
+            "pgsql:host=$host;port=5432;dbname=diff1",
+            'dbdiff',
+            'rootpass',
+            [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+        );
+        $this->dropScratchDb();
+        $this->adminDb->exec("CREATE DATABASE {$this->db}");
+
+        $capsule = new Capsule;
+        $dispatcher = new Dispatcher();
+        $dispatcher->listen(StatementPrepared::class, function ($event) {
+            $event->statement->setFetchMode(PDO::FETCH_ASSOC);
+        });
+        $capsule->setEventDispatcher($dispatcher);
+        $capsule->addConnection([
+            'driver' => 'pgsql', 'host' => $host, 'port' => 5432,
+            'database' => $this->db, 'username' => 'dbdiff', 'password' => 'rootpass',
+            'charset' => 'utf8', 'schema' => 'public',
+        ], 'ovl');
+
+        $this->capsule    = $capsule;
+        $this->connection = $capsule->getConnection('ovl');
+        $this->adapter    = new PostgresAdapter();
+
+        $this->connection->unprepared(<<<'SQL'
+            CREATE FUNCTION cosine_distance(a int,    b int)    RETURNS int    LANGUAGE sql AS $$ SELECT 1 $$;
+            CREATE FUNCTION cosine_distance(a text,   b text)   RETURNS text   LANGUAGE sql AS $$ SELECT 'x' $$;
+            CREATE FUNCTION cosine_distance(a bigint, b bigint) RETURNS bigint LANGUAGE sql AS $$ SELECT 2::bigint $$;
+            CREATE FUNCTION solo() RETURNS int LANGUAGE sql AS $$ SELECT 7 $$;
+
+            CREATE TABLE t1 (id int);
+            CREATE TABLE t2 (id int);
+            CREATE FUNCTION trig_fn() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+            CREATE TRIGGER shared_trig BEFORE INSERT ON t1 FOR EACH ROW EXECUTE FUNCTION trig_fn();
+            CREATE TRIGGER shared_trig BEFORE INSERT ON t2 FOR EACH ROW EXECUTE FUNCTION trig_fn();
+        SQL);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->adminDb === null) {
+            return;
+        }
+        if ($this->connection !== null) {
+            $this->connection->disconnect();
+            $this->connection = null;
+        }
+        $this->capsule = null;
+        $this->dropScratchDb();
+        $this->adminDb = null;
+    }
+
+    private function dropScratchDb(): void
+    {
+        try {
+            $this->adminDb->exec("DROP DATABASE IF EXISTS {$this->db} WITH (FORCE)");
+        } catch (PDOException $e) {
+            $this->adminDb->exec("DROP DATABASE IF EXISTS {$this->db}");
+        }
+    }
+
+    public function testEveryOverloadIsRetained(): void
+    {
+        // Keyed on proname, three overloads collapsed to one entry.
+        $routines = $this->adapter->getRoutines($this->connection);
+        $overloads = array_filter(
+            array_keys($routines),
+            fn($k) => str_starts_with($k, 'cosine_distance')
+        );
+        $this->assertCount(3, $overloads);
+    }
+
+    public function testKeysAreSignaturesNotBareNames(): void
+    {
+        $routines = $this->adapter->getRoutines($this->connection);
+        $this->assertArrayHasKey('cosine_distance(integer,integer)', $routines);
+        $this->assertArrayHasKey('cosine_distance(text,text)', $routines);
+        $this->assertArrayHasKey('cosine_distance(bigint,bigint)', $routines);
+        $this->assertArrayNotHasKey('cosine_distance', $routines);
+    }
+
+    public function testEachOverloadKeepsItsOwnDefinition(): void
+    {
+        $routines = $this->adapter->getRoutines($this->connection);
+        $this->assertStringContainsString('bigint', $routines['cosine_distance(bigint,bigint)']);
+        $this->assertStringContainsString('text', $routines['cosine_distance(text,text)']);
+    }
+
+    public function testNonOverloadedRoutineStillAppears(): void
+    {
+        $routines = $this->adapter->getRoutines($this->connection);
+        $this->assertArrayHasKey('solo()', $routines);
+    }
+
+    public function testRoutineOrderIsDeterministic(): void
+    {
+        // ORDER BY proname left overload ties unordered, which is what made the
+        // surviving definition differ between databases.
+        $first  = array_keys($this->adapter->getRoutines($this->connection));
+        $second = array_keys($this->adapter->getRoutines($this->connection));
+        $this->assertSame($first, $second);
+        $sorted = $first;
+        sort($sorted);
+        $this->assertSame($sorted, $first);
+    }
+
+    public function testSameNamedTriggersOnDifferentTablesAreBothKept(): void
+    {
+        // tgname is unique per table, not per schema — keyed on the name alone,
+        // one of these was silently lost.
+        $triggers = $this->adapter->getTriggers($this->connection);
+        $this->assertArrayHasKey('t1.shared_trig', $triggers);
+        $this->assertArrayHasKey('t2.shared_trig', $triggers);
+        $this->assertSame('shared_trig', $triggers['t1.shared_trig']['name']);
+        $this->assertSame('t2', $triggers['t2.shared_trig']['table']);
+    }
+}

--- a/tests/Unit/RoutineOverloadSQLTest.php
+++ b/tests/Unit/RoutineOverloadSQLTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use DBDiff\SQLGen\DiffToSQL\RoutineDrop;
+use DBDiff\SQLGen\DiffToSQL\DropRoutineSQL;
+use DBDiff\SQLGen\DiffToSQL\AlterRoutineSQL;
+use DBDiff\SQLGen\Dialect\PostgresDialect;
+use DBDiff\SQLGen\Dialect\MySQLDialect;
+use DBDiff\Diff\DropRoutine;
+use DBDiff\Diff\AlterRoutine;
+
+/**
+ * Regression tests for issue #187 — overloaded routines.
+ *
+ * Postgres routines are keyed by signature so overloads stay distinct, which
+ * means the DROP has to carry the argument list. An unqualified DROP is a hard
+ * error once overloads exist:
+ *
+ *     ERROR: function name "cosine_distance" is not unique
+ *
+ * and, were it unambiguous, would remove every overload to recreate one.
+ */
+class RoutineOverloadSQLTest extends TestCase
+{
+    private const FN_DEF = 'CREATE OR REPLACE FUNCTION public.cosine_distance(a text, b text) RETURNS text AS $$ SELECT $$';
+
+    public function testDropCarriesTheArgumentList(): void
+    {
+        $sql = RoutineDrop::build(self::FN_DEF, 'cosine_distance(text,text)', new PostgresDialect());
+        $this->assertSame('DROP FUNCTION IF EXISTS "cosine_distance"(text,text);', $sql);
+    }
+
+    public function testArgumentListSitsOutsideTheQuotedIdentifier(): void
+    {
+        // Quoting the whole signature would yield "cosine_distance(text,text)"
+        // — one odd identifier rather than a call signature.
+        $sql = RoutineDrop::build(self::FN_DEF, 'cosine_distance(text,text)', new PostgresDialect());
+        $this->assertStringNotContainsString('"cosine_distance(text,text)"', $sql);
+        $this->assertStringContainsString('"cosine_distance"(text,text)', $sql);
+    }
+
+    public function testBareNameIsUnchangedForDriversWithoutOverloads(): void
+    {
+        // MySQL has no overloading and passes a bare name.
+        $sql = RoutineDrop::build('CREATE PROCEDURE do_thing()', 'do_thing', new MySQLDialect());
+        $this->assertSame('DROP PROCEDURE IF EXISTS `do_thing`;', $sql);
+    }
+
+    public function testProcedureIsDetectedFromTheDefinition(): void
+    {
+        $sql = RoutineDrop::build('CREATE PROCEDURE public.p(a int)', 'p(integer)', new PostgresDialect());
+        $this->assertStringStartsWith('DROP PROCEDURE IF EXISTS', $sql);
+    }
+
+    public function testFunctionIsTheDefaultType(): void
+    {
+        $sql = RoutineDrop::build('CREATE FUNCTION public.f()', 'f()', new PostgresDialect());
+        $this->assertStringStartsWith('DROP FUNCTION IF EXISTS', $sql);
+    }
+
+    public function testNoArgumentSignatureStillRendersParens(): void
+    {
+        $sql = RoutineDrop::build('CREATE FUNCTION public.f()', 'f()', new PostgresDialect());
+        $this->assertSame('DROP FUNCTION IF EXISTS "f"();', $sql);
+    }
+
+    public function testDropRoutineSQLUsesTheSignature(): void
+    {
+        $obj = new DropRoutine('cosine_distance(text,text)', self::FN_DEF);
+        $sql = (new DropRoutineSQL($obj, new PostgresDialect()))->getUp();
+        $this->assertSame('DROP FUNCTION IF EXISTS "cosine_distance"(text,text);', $sql);
+    }
+
+    public function testAlterRoutineSQLDropsOnlyTheChangedOverload(): void
+    {
+        $source = 'CREATE OR REPLACE FUNCTION public.cosine_distance(a text, b text) RETURNS text AS $$ SELECT 1 $$';
+        $target = 'CREATE OR REPLACE FUNCTION public.cosine_distance(a text, b text) RETURNS text AS $$ SELECT 2 $$';
+        $obj = new AlterRoutine('cosine_distance(text,text)', $source, $target);
+
+        $up = (new AlterRoutineSQL($obj, new PostgresDialect()))->getUp();
+        $this->assertStringContainsString('DROP FUNCTION IF EXISTS "cosine_distance"(text,text);', $up);
+        // The sibling overloads must survive.
+        $this->assertStringNotContainsString('"cosine_distance";', $up);
+    }
+
+    public function testAlterRoutineDownAlsoCarriesTheSignature(): void
+    {
+        $source = 'CREATE OR REPLACE FUNCTION public.f(a int) RETURNS int AS $$ SELECT 1 $$';
+        $target = 'CREATE OR REPLACE FUNCTION public.f(a int) RETURNS int AS $$ SELECT 2 $$';
+        $obj = new AlterRoutine('f(integer)', $source, $target);
+
+        $down = (new AlterRoutineSQL($obj, new PostgresDialect()))->getDown();
+        $this->assertStringContainsString('DROP FUNCTION IF EXISTS "f"(integer);', $down);
+    }
+}

--- a/tests/expected/programmable_objects_pgsql_14.txt
+++ b/tests/expected/programmable_objects_pgsql_14.txt
@@ -2,8 +2,8 @@
 DROP TYPE IF EXISTS "old_status";
 DROP VIEW IF EXISTS "old_report";
 DROP TRIGGER IF EXISTS "trg_old_audit" ON "products";
-DROP FUNCTION IF EXISTS "cleanup_products";
-DROP FUNCTION IF EXISTS "trg_old_audit_fn";
+DROP FUNCTION IF EXISTS "cleanup_products"();
+DROP FUNCTION IF EXISTS "trg_old_audit_fn"();
 CREATE TYPE "order_status" AS ENUM ('pending', 'processing', 'shipped', 'delivered');
 DROP TYPE IF EXISTS "priority";
 CREATE TYPE "priority" AS ENUM ('low', 'medium', 'high', 'critical');
@@ -48,8 +48,8 @@ BEGIN
   RETURN OLD;
 END;
 $function$;
-DROP FUNCTION IF EXISTS "get_product_count";
-DROP FUNCTION IF EXISTS "trg_products_updated_fn";
+DROP FUNCTION IF EXISTS "get_product_count"();
+DROP FUNCTION IF EXISTS "trg_products_updated_fn"();
 CREATE TRIGGER trg_old_audit AFTER DELETE ON public.products FOR EACH ROW EXECUTE FUNCTION trg_old_audit_fn();
 DROP TRIGGER IF EXISTS "trg_products_updated" ON "products";
 CREATE VIEW "old_report" AS SELECT products.id,

--- a/tests/expected/programmable_objects_pgsql_15.txt
+++ b/tests/expected/programmable_objects_pgsql_15.txt
@@ -2,8 +2,8 @@
 DROP TYPE IF EXISTS "old_status";
 DROP VIEW IF EXISTS "old_report";
 DROP TRIGGER IF EXISTS "trg_old_audit" ON "products";
-DROP FUNCTION IF EXISTS "cleanup_products";
-DROP FUNCTION IF EXISTS "trg_old_audit_fn";
+DROP FUNCTION IF EXISTS "cleanup_products"();
+DROP FUNCTION IF EXISTS "trg_old_audit_fn"();
 CREATE TYPE "order_status" AS ENUM ('pending', 'processing', 'shipped', 'delivered');
 DROP TYPE IF EXISTS "priority";
 CREATE TYPE "priority" AS ENUM ('low', 'medium', 'high', 'critical');
@@ -48,8 +48,8 @@ BEGIN
   RETURN OLD;
 END;
 $function$;
-DROP FUNCTION IF EXISTS "get_product_count";
-DROP FUNCTION IF EXISTS "trg_products_updated_fn";
+DROP FUNCTION IF EXISTS "get_product_count"();
+DROP FUNCTION IF EXISTS "trg_products_updated_fn"();
 CREATE TRIGGER trg_old_audit AFTER DELETE ON public.products FOR EACH ROW EXECUTE FUNCTION trg_old_audit_fn();
 DROP TRIGGER IF EXISTS "trg_products_updated" ON "products";
 CREATE VIEW "old_report" AS SELECT products.id,

--- a/tests/expected/programmable_objects_pgsql_16.txt
+++ b/tests/expected/programmable_objects_pgsql_16.txt
@@ -2,8 +2,8 @@
 DROP TYPE IF EXISTS "old_status";
 DROP VIEW IF EXISTS "old_report";
 DROP TRIGGER IF EXISTS "trg_old_audit" ON "products";
-DROP FUNCTION IF EXISTS "cleanup_products";
-DROP FUNCTION IF EXISTS "trg_old_audit_fn";
+DROP FUNCTION IF EXISTS "cleanup_products"();
+DROP FUNCTION IF EXISTS "trg_old_audit_fn"();
 CREATE TYPE "order_status" AS ENUM ('pending', 'processing', 'shipped', 'delivered');
 DROP TYPE IF EXISTS "priority";
 CREATE TYPE "priority" AS ENUM ('low', 'medium', 'high', 'critical');
@@ -48,8 +48,8 @@ BEGIN
   RETURN OLD;
 END;
 $function$;
-DROP FUNCTION IF EXISTS "get_product_count";
-DROP FUNCTION IF EXISTS "trg_products_updated_fn";
+DROP FUNCTION IF EXISTS "get_product_count"();
+DROP FUNCTION IF EXISTS "trg_products_updated_fn"();
 CREATE TRIGGER trg_old_audit AFTER DELETE ON public.products FOR EACH ROW EXECUTE FUNCTION trg_old_audit_fn();
 DROP TRIGGER IF EXISTS "trg_products_updated" ON "products";
 CREATE VIEW "old_report" AS SELECT id,

--- a/tests/expected/programmable_objects_pgsql_17.txt
+++ b/tests/expected/programmable_objects_pgsql_17.txt
@@ -2,8 +2,8 @@
 DROP TYPE IF EXISTS "old_status";
 DROP VIEW IF EXISTS "old_report";
 DROP TRIGGER IF EXISTS "trg_old_audit" ON "products";
-DROP FUNCTION IF EXISTS "cleanup_products";
-DROP FUNCTION IF EXISTS "trg_old_audit_fn";
+DROP FUNCTION IF EXISTS "cleanup_products"();
+DROP FUNCTION IF EXISTS "trg_old_audit_fn"();
 CREATE TYPE "order_status" AS ENUM ('pending', 'processing', 'shipped', 'delivered');
 DROP TYPE IF EXISTS "priority";
 CREATE TYPE "priority" AS ENUM ('low', 'medium', 'high', 'critical');
@@ -48,8 +48,8 @@ BEGIN
   RETURN OLD;
 END;
 $function$;
-DROP FUNCTION IF EXISTS "get_product_count";
-DROP FUNCTION IF EXISTS "trg_products_updated_fn";
+DROP FUNCTION IF EXISTS "get_product_count"();
+DROP FUNCTION IF EXISTS "trg_products_updated_fn"();
 CREATE TRIGGER trg_old_audit AFTER DELETE ON public.products FOR EACH ROW EXECUTE FUNCTION trg_old_audit_fn();
 DROP TRIGGER IF EXISTS "trg_products_updated" ON "products";
 CREATE VIEW "old_report" AS SELECT id,

--- a/tests/expected/programmable_objects_pgsql_18.txt
+++ b/tests/expected/programmable_objects_pgsql_18.txt
@@ -2,8 +2,8 @@
 DROP TYPE IF EXISTS "old_status";
 DROP VIEW IF EXISTS "old_report";
 DROP TRIGGER IF EXISTS "trg_old_audit" ON "products";
-DROP FUNCTION IF EXISTS "cleanup_products";
-DROP FUNCTION IF EXISTS "trg_old_audit_fn";
+DROP FUNCTION IF EXISTS "cleanup_products"();
+DROP FUNCTION IF EXISTS "trg_old_audit_fn"();
 CREATE TYPE "order_status" AS ENUM ('pending', 'processing', 'shipped', 'delivered');
 DROP TYPE IF EXISTS "priority";
 CREATE TYPE "priority" AS ENUM ('low', 'medium', 'high', 'critical');
@@ -48,8 +48,8 @@ BEGIN
   RETURN OLD;
 END;
 $function$;
-DROP FUNCTION IF EXISTS "get_product_count";
-DROP FUNCTION IF EXISTS "trg_products_updated_fn";
+DROP FUNCTION IF EXISTS "get_product_count"();
+DROP FUNCTION IF EXISTS "trg_products_updated_fn"();
 CREATE TRIGGER trg_old_audit AFTER DELETE ON public.products FOR EACH ROW EXECUTE FUNCTION trg_old_audit_fn();
 DROP TRIGGER IF EXISTS "trg_products_updated" ON "products";
 CREATE VIEW "old_report" AS SELECT id,

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -28,6 +28,7 @@
             <file>./End2EndPostgresTest.php</file>
             <file>./DBDiffComprehensivePostgresTest.php</file>
             <file>./BulkSchemaPostgresTest.php</file>
+            <file>./RoutineOverloadPostgresTest.php</file>
         </testsuite>
         <testsuite name="SQLite">
             <file>./End2EndSQLiteTest.php</file>


### PR DESCRIPTION
Fixes #187.

`getRoutines()` keyed its map on `proname`, but Postgres allows several functions to share a name with different argument signatures. Overloads overwrote each other, so **N−1 were invisible to the diff entirely** — genuine drift in them was missed — and which one survived depended on row order, which differs between databases.

## Reproduced

Three identical `cosine_distance` overloads, created in a different order in each database. The schemas are content-identical (both hash to `058b5b2e16392bd9710a81b99769fa24`), but `getRoutines`' own query returns them in different orders:

```
--- ovl_a ---                        --- ovl_b ---
cosine_distance -> RETURNS integer   cosine_distance -> RETURNS bigint
cosine_distance -> RETURNS text      cosine_distance -> RETURNS text
cosine_distance -> RETURNS bigint    cosine_distance -> RETURNS integer
```

Last row wins, so one side kept `bigint` and the other `integer`, and dbdiff generated a migration for two identical schemas. That migration did not even run:

```
DROP FUNCTION IF EXISTS "cosine_distance";
ERROR:  function name "cosine_distance" is not unique
HINT:  Specify the argument list to select the function unambiguously.
```

Had it been unambiguous it would have removed all three overloads to recreate one.

## Fix

**Key by signature.** `p.oid::regprocedure::text` renders as `cosine_distance(integer,integer)` — unique per overload and stable across databases, unlike `oid`. Ordering by the same expression makes the result deterministic, where `ORDER BY proname` left ties unordered.

**Carry the argument list into the DROP.** `RoutineDrop::build()` appends it *outside* the quoted identifier — quoting the whole signature yields `"fn(integer,text)"`, one odd identifier rather than a call signature. A bare name (MySQL, which has no overloading) passes through unchanged.

Three SQL generators carried identical private copies of the drop builder, so this consolidates them rather than writing the argument handling three times. `CreateRoutineSQL` was the third and I initially missed it — the golden-file tests caught it, emitting `"get_product_count()"` with the parens inside the quotes.

**Triggers had the same class of bug.** `tgname` is unique per table, not per schema, so two tables sharing a trigger name silently lost one — confirmed on a live server. Now keyed by table and name, with the bare name carried alongside so the emitted DDL is unchanged.

## Verification

End to end against PostgreSQL 16:

- Identical schemas containing overloads → **no drift** (previously a spurious migration).
- One overload genuinely changed → `DROP FUNCTION IF EXISTS "cosine_distance"(text,text);`, which **applies cleanly** and leaves the other two overloads intact (2 remaining, not 0).
- Both same-named triggers on different tables now appear in the diff; previously one vanished.

**803 tests pass**, 15 of them new: 9 unit tests for the drop builder (argument list placement, bare names, PROCEDURE vs FUNCTION detection, both Alter directions) and 6 live-server tests for overload retention, signature keys, per-overload definitions, deterministic ordering, and the trigger collision.

## Golden fixtures

`programmable_objects_pgsql_14` through `18` updated for the argument-qualified DROP. The bare form was the bug, so the fixtures were encoding it. Both affected functions are zero-argument, so the change is `"name";` → `"name"();` identically on every version — verified directly on 16, and CI covers 14/15/17/18.

`PostgresAdapter` stays at 20 methods; the new `RoutineDrop` has 2.

## Second commit: pinning the Dolt image

Unrelated to the fix, but it is what was holding CI red, so it rides along.

`dolthub/dolt-sql-server:latest` was the only unpinned database image in the repo — mysql and postgres are version-pinned everywhere, in CI and in docker-compose. On 2026-08-13 `latest` moved 2.2.3 → 2.3.0, after master's last green run, and the Dolt matrix started failing on branches that had not touched the code.

The failures are Dolt-side and non-deterministic — two runs of the *same commit* errored 9 tests and then 4, on different tests each time, all with:

```
PDOException: SQLSTATE[HY000]: General error: 1105 context canceled
```

thrown from `loadFixture()` while executing the fixture `.sql`. That is plain DDL, before any DBDiff code runs, and the sidecar log shows the server cancelling in-flight queries alongside `stats stopped: context canceled`. The last master run on 2.2.3 had zero such errors.

Pinned to 2.2.3 in CI, and `docker-compose.yml` now reads the `DOLT_VERSION` variable that `.env.example` already defined but nothing consumed, so local runs match CI. Worth revisiting once a Dolt release fixes the cancellation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)