### PR TITLE
ci: stop the binary builds depending on musl.libc.org being up

### DIFF
--- a/.github/scripts/prepare-musl.sh
+++ b/.github/scripts/prepare-musl.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Make `spc doctor --auto-fix` survive musl.libc.org being unreachable.
+#
+# spc's fix-musl-wrapper fetches musl source from https://musl.libc.org — a
+# single lightly-provisioned origin with no CDN. When it is down, every Linux
+# leg fails after a ~135s connect timeout; the retry loop added in #185 helps
+# with a blip but cannot help with an outage, because each attempt hits the
+# same dead host. This has now cost us a release (#185) and a PR run.
+#
+# Two layers, in the order the build should prefer them:
+#
+#   1. RESTORE — if a previous run's musl install was cached, put it back.
+#      spc's checkMusl()/checkMuslCrossMake() are pure file-existence tests, so
+#      a restored install makes doctor a no-op and nothing is downloaded.
+#
+#   2. PRE-SEED — otherwise fetch the tarball ourselves (origin first, then
+#      mirrors) and register it in spc's lock file, so spc's own fixMusl()
+#      finds it already downloaded and skips the network.
+#
+# Pre-seeding rather than installing musl ourselves is deliberate: spc applies
+# the CVE-2025-26519 patches after unpacking, and hand-rolling the install would
+# silently drop them. We supply the bytes; spc still patches and installs.
+#
+# The download is verified against a pinned SHA-256 and fails closed on
+# mismatch. A mirror is only ever a byte source, never a trust anchor — a
+# compromised mirror must not be able to substitute a backdoored libc.
+#
+# Usage:  prepare-musl.sh <cache-dir>
+#   <cache-dir> is a workspace path that actions/cache saves and restores.
+
+CACHE_DIR="${1:-musl-cache}"
+
+# Pinned to the version hardcoded in spc's LinuxMuslCheck::fixMusl(). If spc
+# bumps it, this stops matching and we simply fall through to spc's own
+# download — degraded to today's behaviour, never broken.
+MUSL_VERSION="musl-1.2.5"
+MUSL_SHA256="a9a118bbe84d8764da0ea0d28b3ab3fae8477fc7e4085d90102b8596fc7c75e4"
+
+# Origin first: it is the canonical source and usually works. The mirrors are
+# distribution archives that were verified byte-identical to the origin tarball
+# and to each other at the time of writing.
+MUSL_URLS=(
+  "https://musl.libc.org/releases/${MUSL_VERSION}.tar.gz"
+  "https://distfiles.macports.org/musl/${MUSL_VERSION}.tar.gz"
+  "https://sources.buildroot.net/musl/${MUSL_VERSION}.tar.gz"
+)
+
+ARCH="$(uname -m)"
+WRAPPER="/lib/ld-musl-${ARCH}.so.1"
+MUSL_PREFIX="/usr/local/musl"
+
+log() { printf '  [musl] %s\n' "$*"; }
+
+# ── 1. restore a cached install ──────────────────────────────────────────────
+# checkMusl() wants the wrapper AND ${MUSL_PREFIX}/lib/libc.a; checkMuslCrossMake()
+# wants the cross toolchain under the same prefix. Restoring the whole prefix
+# plus the wrapper satisfies both, so doctor finds nothing to fix.
+if [ -f "$CACHE_DIR/musl-prefix.tar.gz" ]; then
+  log "restoring cached musl toolchain"
+  sudo tar -xzf "$CACHE_DIR/musl-prefix.tar.gz" -C / || true
+
+  if [ -f "${MUSL_PREFIX}/lib/libc.a" ] && [ -f "$WRAPPER" ]; then
+    log "restored — doctor will skip fix-musl-wrapper, no download needed"
+    exit 0
+  fi
+  log "cache incomplete, falling through to pre-seed"
+fi
+
+# ── 2. pre-seed spc's download directory ─────────────────────────────────────
+mkdir -p downloads
+TARBALL="downloads/${MUSL_VERSION}.tar.gz"
+
+verify() {
+  local actual
+  actual="$(sha256sum "$1" | cut -d' ' -f1)"
+  [ "$actual" = "$MUSL_SHA256" ] || { log "checksum MISMATCH (got $actual)"; return 1; }
+}
+
+if [ -f "$TARBALL" ] && verify "$TARBALL" 2>/dev/null; then
+  log "tarball already present and verified"
+else
+  fetched=false
+  for url in "${MUSL_URLS[@]}"; do
+    log "fetching ${url}"
+    # Short connect timeout: a dead origin should cost seconds, not the ~135s
+    # the default takes, so we reach the mirrors quickly.
+    if curl -fsSL --connect-timeout 20 --max-time 300 -o "${TARBALL}.part" "$url" 2>/dev/null; then
+      if verify "${TARBALL}.part"; then
+        mv -f "${TARBALL}.part" "$TARBALL"
+        log "verified sha256 ${MUSL_SHA256}"
+        fetched=true
+        break
+      fi
+      # Wrong bytes from a reachable host is a supply-chain signal, not a
+      # transient error: refuse this source outright rather than retrying it.
+      log "REFUSING ${url} — content did not match the pinned checksum"
+    else
+      log "unreachable, trying next source"
+    fi
+    rm -f "${TARBALL}.part"
+  done
+
+  if [ "$fetched" != true ]; then
+    # Not fatal: spc will attempt its own download and may succeed. Failing here
+    # would turn a soft degradation into a hard one.
+    log "WARNING: could not obtain a verified ${MUSL_VERSION}.tar.gz from any source"
+    log "         leaving spc to try its own download"
+    exit 0
+  fi
+fi
+
+# Tell spc the source is already downloaded. Its isAlreadyDownloaded() checks
+# the lock entry and that the file exists; without the entry it re-downloads
+# regardless of the file being there.
+python3 - "$MUSL_VERSION" <<'PY' || log "could not update lock file; spc will download normally"
+import json, os, sys
+name = sys.argv[1]
+path = os.path.join('downloads', '.lock.json')
+data = {}
+if os.path.exists(path):
+    try:
+        with open(path) as fh:
+            data = json.load(fh)
+    except (ValueError, OSError):
+        data = {}
+data[name] = {
+    'source_type': 'archive',   # SPC_SOURCE_ARCHIVE
+    'filename': f'{name}.tar.gz',
+    'move_path': None,
+    'lock_as': 1,               # SPC_DOWNLOAD_SOURCE
+}
+with open(path, 'w') as fh:
+    json.dump(data, fh, indent=4)
+print(f'  [musl] registered {name} in downloads/.lock.json')
+PY

--- a/.github/workflows/binary-check.yml
+++ b/.github/workflows/binary-check.yml
@@ -152,6 +152,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Restore cached artifacts so we can skip the 30-60 min compile.
+          mkdir -p spc-cache
           if [ -d spc-cache/buildroot ]; then
             echo "Restoring SPC buildroot from cache..."
             cp -a spc-cache/buildroot buildroot
@@ -164,12 +165,26 @@ jobs:
             cp -a spc-cache/downloads downloads
           fi
 
-          ./spc doctor --auto-fix
-
           if [ -f buildroot/bin/micro.sfx ]; then
-            echo "Cache hit — reusing micro.sfx, skipping SPC download + build."
+            # Nothing is compiled on a cache hit, so the musl toolchain is not
+            # needed. Running doctor here anyway meant a fully cached run — one
+            # that does no build at all — still reached out to musl.libc.org and
+            # failed with it when that host was down.
+            echo "Cache hit — reusing micro.sfx, skipping SPC doctor, download and build."
           else
             echo "No cache — building from scratch (~30-60 min)..."
+
+            # Restore or pre-seed musl before doctor, so fix-musl-wrapper does
+            # not depend on a single origin being reachable. See the script.
+            .github/scripts/prepare-musl.sh spc-cache
+
+            SPC_DOWNLOAD_RETRIES=3 ./spc doctor --auto-fix
+
+            # Keep the installed toolchain for the next run: spc's musl checks
+            # are file-existence tests, so a restored install skips the fix.
+            tar -czf spc-cache/musl-prefix.tar.gz \
+              /usr/local/musl "/lib/ld-musl-$(uname -m).so.1" 2>/dev/null || true
+
             ./spc download \
               "php-src,micro,${{ env.SPC_EXTENSIONS }},${{ env.SPC_LIBS }}" \
               --with-php="${{ env.SPC_PHP_VERSION }}"

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -178,11 +178,19 @@ jobs:
             cp -a spc-cache/downloads downloads
           fi
 
-          ./spc doctor --auto-fix
-
           if [ -f buildroot/bin/micro.sfx ]; then
-            echo "Cache hit — reusing micro.sfx"
+            # No compile on a cache hit, so no musl toolchain is needed and
+            # musl.libc.org is never contacted.
+            echo "Cache hit — reusing micro.sfx, skipping SPC doctor"
           else
+            mkdir -p spc-cache
+            .github/scripts/prepare-musl.sh spc-cache
+
+            SPC_DOWNLOAD_RETRIES=3 ./spc doctor --auto-fix
+
+            tar -czf spc-cache/musl-prefix.tar.gz \
+              /usr/local/musl "/lib/ld-musl-$(uname -m).so.1" 2>/dev/null || true
+
             ./spc download \
               "php-src,micro,${{ env.SPC_EXTENSIONS }},${{ env.SPC_LIBS }}" \
               --with-php="${{ env.SPC_PHP_VERSION }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,6 +188,24 @@ jobs:
         run: |
           echo "$USER ALL=(ALL) NOPASSWD: ALL" | sudo tee -a /etc/sudoers
 
+      # ── musl toolchain cache (Linux) ──────────────────────────────────────
+      # spc's fix-musl-wrapper fetches musl source from musl.libc.org, a single
+      # origin with no CDN. Its checks are file-existence tests, so a restored
+      # install makes doctor a no-op and the release stops depending on that
+      # host being up. Keyed on the spc version, which pins the musl version.
+      - name: Cache musl toolchain (Linux)
+        if: runner.os == 'Linux'
+        uses: actions/cache@v4
+        with:
+          path: musl-cache
+          key: musl-${{ runner.os }}-${{ runner.arch }}-spc${{ env.SPC_VERSION }}
+
+      - name: Restore or pre-seed musl (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          mkdir -p musl-cache
+          .github/scripts/prepare-musl.sh musl-cache
+
       # ── Build static PHP micro SAPI (all Unix targets) ────────────────────
       - name: Build static PHP binary (Unix)
         if: runner.os != 'Windows'
@@ -203,6 +221,9 @@ jobs:
           # timeout there (curl exit 28, after ~134s) killed three Linux legs of
           # the v3.0.0-rc.5 release and shipped a partial package set. See #185.
           # Retry with backoff so one transient timeout does not fail the leg.
+          # SPC_DOWNLOAD_RETRIES makes spc retry inside a single doctor run;
+          # the loop below still covers a failure that survives those.
+          export SPC_DOWNLOAD_RETRIES=3
           for attempt in 1 2 3; do
             if ./spc doctor --auto-fix; then
               break
@@ -215,6 +236,15 @@ jobs:
             echo "spc doctor attempt ${attempt} failed — retrying in ${backoff}s ..."
             sleep "$backoff"
           done
+
+          # Persist the toolchain so the next release restores it instead of
+          # downloading musl again.
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            mkdir -p musl-cache
+            tar -czf musl-cache/musl-prefix.tar.gz \
+              /usr/local/musl "/lib/ld-musl-$(uname -m).so.1" 2>/dev/null || true
+          fi
+
           ./spc download \
             "php-src,micro,${{ env.SPC_EXTENSIONS }},${{ env.SPC_LIBS }}" \
             --with-php="${{ env.SPC_PHP_VERSION }}"


### PR DESCRIPTION
## The problem

`spc doctor --auto-fix` runs `fix-musl-wrapper`, which fetches musl source from `https://musl.libc.org` — a single lightly-provisioned origin with no CDN, and spc performs no retry of its own. When it is unreachable, every Linux leg dies after a ~135s connect timeout:

```
Automatically fixing fix-musl-wrapper ...
[I] Downloading https://musl.libc.org/releases/musl-1.2.5.tar.gz
curl: (28) Failed to connect to musl.libc.org port 443 after 135038 ms
Fix failed: Download failed: Direct command run failed with code: 28
```

This took out three Linux legs of v3.0.0-rc.5 and shipped a partial package set (#185). It has since failed a PR run and a release again.

**The retry loop from #185 cannot fix this.** It handles a blip; during an outage all three attempts hit the same dead host, so it spends seven minutes arriving at the same failure. Confirmed independently while investigating: `musl.libc.org` resolved fine (A `45.63.0.111`, AAAA present) but TCP/443 was unreachable for an extended period.

## The fix

Two layers, preferring the one that needs no network at all.

**1. Cache the installed toolchain.** `checkMusl()` and `checkMuslCrossMake()` are pure file-existence tests — `/lib/ld-musl-<arch>.so.1` and files under `/usr/local/musl`. Restoring a previous install makes doctor a no-op and nothing is fetched. `release.yml` had no cache at all and rebuilt from scratch every release.

**2. Pre-seed when the cache misses.** `.github/scripts/prepare-musl.sh` fetches the tarball itself — origin first, then two distribution mirrors — and registers it in spc's lock file.

The lock entry is necessary, not belt-and-braces: `Downloader::downloadFile()` never skips an existing file, and `isAlreadyDownloaded()` gates on `downloads/.lock.json` having a matching entry. Dropping the tarball in alone gets it re-downloaded regardless.

**Pre-seeding rather than installing musl ourselves is deliberate.** `fixMusl()` applies the CVE-2025-26519 patches after unpacking; hand-rolling the install would silently drop them. We supply the bytes, spc still patches and installs.

## Supply chain

The download is verified against a pinned SHA-256 and **fails closed**. A mirror is a byte source, never a trust anchor — a compromised mirror must not be able to substitute a backdoored libc into the binaries we ship.

Both mirrors were verified before being added:

| Source | Bytes | SHA-256 |
|---|---|---|
| distfiles.macports.org | 1,080,786 | `a9a118bb…7c75e4` |
| sources.buildroot.net | 1,080,786 | `a9a118bb…7c75e4` |

Byte-identical to each other and to the official musl 1.2.5 tarball.

On mismatch the source is refused outright rather than retried — wrong bytes from a *reachable* host is a supply-chain signal, not a transient error. If no source verifies, the script warns and leaves spc to try its own download: a soft degradation to today's behaviour rather than a hard failure.

## Also fixed

`binary-check.yml` and `release-dry-run.yml` called `doctor --auto-fix` *before* the cache-hit check, so a fully cached run — one that compiles nothing at all — still contacted musl.libc.org and failed with it. That is what failed on #190. Doctor now runs only on the path that actually builds.

`SPC_DOWNLOAD_RETRIES=3` is also set, giving spc retries within a single doctor run underneath the existing outer loop.

## Version drift

The pin matches the version hardcoded in spc's `fixMusl()`. If spc bumps it, the pin stops matching and we fall through to spc's own download — degraded to today's behaviour, never worse. Nothing silently installs an unverified musl.

## Verification

The script was exercised against every path:

| Scenario | Result |
|---|---|
| origin reachable | uses origin, verified |
| origin unreachable | falls through to mirror, verified |
| **hostile mirror, wrong bytes** | **refused — no tarball, no lock entry** |
| warm cache | restores install, zero network |
| partial/corrupt cache | falls through to pre-seed |

`actionlint` and `shellcheck` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)