### PR TITLE
fix(docker): make the full image buildable, and fail the release when it is not

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,6 +20,11 @@ vendor/
 docker-compose*.yml
 docs/
 images/
-scripts/
-tests/
 .github/
+
+# scripts/ and tests/ are NOT excluded: docker/Dockerfile (the "full" image)
+# copies both, because that image exists for local development and
+# cross-version testing via start.sh. Excluding them made every full-image
+# build fail at COPY with `"/scripts": not found`, and the failure went
+# unnoticed for months because the release step is continue-on-error.
+# Dockerfile.slim copies neither, so this costs it only build context.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -713,6 +713,36 @@ jobs:
             echo "::warning::❌ GHCR login failed"
           fi
 
+      # ── Validate both images before any push ──────────────────────────────
+      # The push steps below are continue-on-error so a registry outage cannot
+      # block the rest of the release. That also swallowed genuine build
+      # failures: docker/Dockerfile could not build at all for months (COPY of
+      # paths excluded by .dockerignore) and every release still reported
+      # success while publishing no full image.
+      #
+      # These steps build without pushing and are NOT continue-on-error, so a
+      # broken Dockerfile fails the release loudly. Layers land in the gha
+      # cache, so the push steps below reuse them rather than rebuilding.
+      - name: Validate slim image builds
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.slim
+          platforms: linux/amd64,linux/arm64
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Validate full image builds
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       # ── Slim image (PHAR + PHP Alpine) ────────────────────────────────────
       # Tags: latest, {version}, slim-{version}
       - name: Build and push slim image to GHCR


### PR DESCRIPTION
## The problem

`docker/Dockerfile` (the **full** image) copies `scripts/` and `tests/` — that image exists for local development and cross-version testing via `start.sh` — but `.dockerignore` excluded both:

```
COPY --chown=root:root --chmod=755 scripts/ scripts/
ERROR: failed to compute cache key: failed to calculate checksum of ref ...: "/scripts": not found
```

`Dockerfile.slim` copies neither, which is why only the full image failed.

## How long, and what it cost

Broken since `6ef36c5` (2026-03-22, *"tighten .dockerignore"*) — five months.

I checked the registry rather than assuming:

| Tag | Status |
|---|---|
| `ghcr.io/dbdiff/dbdiff:latest` | 200 |
| `ghcr.io/dbdiff/dbdiff:3.0.0-rc.8` | 200 |
| **`ghcr.io/dbdiff/dbdiff:full`** | **404** |
| **`ghcr.io/dbdiff/dbdiff:full-3.0.0-rc.8`** | **404** |

The full image has never been published. The documented tag simply does not exist.

## Why nobody noticed

The push steps are `continue-on-error: true`. That is right for a registry outage — a Docker Hub problem should not block GHCR — but it also swallowed a build that could never succeed. buildx logged `##[error] buildx failed with: ERROR: failed to build`, and the job still concluded **success**, so every release reported green while publishing nothing.

## The fix

**1. `.dockerignore` no longer excludes `scripts/` or `tests/`.** `Dockerfile.slim` copies neither, so this costs it only build context.

**2. Both images are built without pushing, before any push step, and those validation steps are *not* `continue-on-error`.** A broken Dockerfile now fails the release loudly, while registry resilience is preserved for the actual pushes. Layers land in the gha cache, so the push steps reuse them rather than rebuilding.

## Verification

Reproduced the failure locally with podman, then confirmed the fix:

- full image **builds**, and contains `/usr/src/dbdiff/scripts`, `/usr/src/dbdiff/tests` and `/usr/src/dbdiff/src` as the Dockerfile intends
- full image **runs** (its entrypoint waits on `db:3306`, the expected compose behaviour)
- slim image **unaffected**
- `actionlint` clean

## Worth considering separately

Images are only built during `release.yml`, so even with this change a broken Dockerfile is caught at release time rather than on the PR that breaks it. Adding a build-only job to the PR workflow would move that left. Left out here to keep this change focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)