### PR TITLE
test: assert routines are created before the views and triggers that call them

### DIFF
--- a/tests/Unit/DiffSorterProgrammableTest.php
+++ b/tests/Unit/DiffSorterProgrammableTest.php
@@ -32,8 +32,11 @@ class DiffSorterProgrammableTest extends TestCase
     }
 
     /**
-     * UP order: DropView/DropTrigger/DropRoutine come before AddTable,
-     * and CreateView/CreateTrigger/CreateRoutine come after data ops.
+     * UP order: DropView/DropTrigger/DropRoutine come before AddTable, and
+     * CreateView/CreateTrigger come after data ops.
+     *
+     * CreateRoutine is no longer in that trailing group — see
+     * testUpOrderCreateRoutineBeforeItsCallers.
      */
     public function testUpOrderDropsProgrammableBeforeTables(): void
     {
@@ -185,6 +188,39 @@ class DiffSorterProgrammableTest extends TestCase
         $names  = array_map([$this, 'className'], $sorted);
 
         $this->assertSame(['DropEnum', 'AddTable'], $names);
+    }
+
+    /**
+     * A function must exist before anything that calls it.
+     *
+     * CreateRoutine used to sort last, after CreateView and CreateTrigger, so a
+     * trigger whose function was also new was emitted before the function:
+     *
+     *   CREATE TRIGGER tg ... EXECUTE FUNCTION f();
+     *   CREATE OR REPLACE FUNCTION public.f() ...
+     *   ERROR: function f() does not exist
+     *
+     * The fix shipped in 3.0.0-rc.9 but had no test of its own — it was only
+     * covered incidentally by a partition-trigger test that happens to need a
+     * function, so a regression would have pointed at triggers rather than at
+     * ordering. Views have the same dependency and are asserted here too.
+     */
+    public function testUpOrderCreateRoutineBeforeItsCallers(): void
+    {
+        $diffs = [
+            new CreateTrigger('trg1', 't1', 'CREATE TRIGGER ...'),
+            new CreateView('v1', 'CREATE VIEW ...'),
+            new CreateRoutine('fn1', 'CREATE FUNCTION ...'),
+        ];
+
+        $names = array_map([$this, 'className'], $this->sorter->sort($diffs, 'up'));
+
+        $routineIdx = array_search('CreateRoutine', $names);
+        $viewIdx    = array_search('CreateView', $names);
+        $triggerIdx = array_search('CreateTrigger', $names);
+
+        $this->assertLessThan($viewIdx, $routineIdx, 'CreateRoutine before CreateView');
+        $this->assertLessThan($triggerIdx, $routineIdx, 'CreateRoutine before CreateTrigger');
     }
 
     /**


### PR DESCRIPTION
## Why

The routine-ordering fix shipped in `3.0.0-rc.9` (#192) **with no test of its own**.

It was covered only *incidentally* — by a partition-trigger test that happens to need a function to exist. So a regression would have failed pointing at **triggers** rather than at ordering, and only on the Postgres legs. That is the kind of coverage that looks fine on a green run and misleads you on a red one.

I found this auditing my own work rather than from a failure, which is the better time to find it.

## The bug it guards

`CreateRoutine` used to sort last, after `CreateView` and `CreateTrigger`, so a trigger whose function was also new was emitted before the function existed:

```sql
CREATE TRIGGER tg AFTER INSERT ON public.t ... EXECUTE FUNCTION f();
CREATE OR REPLACE FUNCTION public.f() ...
```

```
ERROR: function f() does not exist
```

Views have the same dependency, so both are asserted.

## It earns its place

Verified the test actually fails without the fix rather than assuming it:

```
# DiffSorter reverted to the previous order
Failed asserting that 2 is less than 0.
FAILURES! Tests: 1, Assertions: 1, Failures: 1.

# fix restored
OK (21 tests, 35 assertions)
```

## Also

The docblock on `testUpOrderDropsProgrammableBeforeTables` still described `CreateRoutine` as part of the trailing group with `CreateView` and `CreateTrigger` — which stopped being true when the fix landed. Stale comments that contradict behaviour are worse than none, so it now points at the new test.

Postgres suite **47 tests / 139 assertions**; unit + SQLite **334 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)