### PR TITLE
ci(release): install NASM on Windows, and prove the binaries have their drivers

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -220,11 +220,9 @@ jobs:
       # OpenSSL's Windows build assembles with NASM. It was present on the
       # runner image until it was not, and `spc doctor --auto-fix` only repairs
       # the prerequisites it knows about — so it reported a clean bill of health
-      # and the build died much later with "NASM not found", inside the openssl
-      # module, with nothing pointing at the real cause.
-      #
-      # Installing it explicitly also pins the responsibility here rather than
-      # on whatever the image happens to ship next month.
+      # and the build died much later inside the openssl module, with nothing
+      # pointing at the real cause. Unlike the musl failures this is not
+      # transient: there is nothing to retry.
       - name: Install NASM (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
@@ -261,14 +259,14 @@ jobs:
           set -euo pipefail
           ./dbdiff --version
 
-          # --version passes even if every database driver is missing. The
+          # --version passes even with no database drivers compiled in. The
           # Windows leg builds pdo_pgsql against libpq copied out of the
-          # postgresql-win archive, and that copy has failed silently before —
-          # leaving a Postgres diff tool with no Postgres support.
+          # postgresql-win archive, and those copies have failed silently
+          # before — which would ship a Postgres diff tool with no Postgres.
           #
-          # PDO reports a missing driver as exactly "could not find driver",
-          # and an unreachable server as a connection error, so pointing each
-          # driver at a closed port tells the two apart.
+          # PDO reports a missing driver as exactly "could not find driver" and
+          # an unreachable server as a connection error, so a closed port tells
+          # the two apart without needing a live database.
           for scheme in postgresql mysql; do
             out="$(./dbdiff diff \
               --server1-url "$scheme://u:p@127.0.0.1:1/x" \
@@ -301,6 +299,39 @@ jobs:
             Write-Output "$scheme driver present"
           }
 
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: dbdiff${{ startsWith(matrix.target, 'win32') && '.exe' || '' }}
+          retention-days: 1
+
+  # ═══════════════════════════════════════════════════════════════════════════
+  # JOB 3 — npm dry-run publish + registry health check
+  # ═══════════════════════════════════════════════════════════════════════════
+  npm-dry-run:
+    name: "npm dry-run publish"
+    needs: [build-phar, build-binary]
+    if: ${{ !cancelled() && needs.build-phar.result == 'success' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: binaries/
+          pattern: dbdiff-*
+          merge-multiple: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      # `npm publish --dry-run` never authenticates, so it can't tell us whether
+      # NPM_TOKEN is still valid. `npm whoami` makes a real authenticated call —
+      # it fails fast here if the token is missing/expired, before a real release
+      # would fail at the publish step.
       - name: Verify NPM_TOKEN is valid
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -217,6 +217,26 @@ jobs:
         run: |
           Invoke-WebRequest -Uri "https://github.com/crazywhalecc/static-php-cli/releases/download/${{ env.SPC_VERSION }}/spc-windows-x64.exe" -OutFile spc.exe
 
+      # OpenSSL's Windows build assembles with NASM. It was present on the
+      # runner image until it was not, and `spc doctor --auto-fix` only repairs
+      # the prerequisites it knows about — so it reported a clean bill of health
+      # and the build died much later with "NASM not found", inside the openssl
+      # module, with nothing pointing at the real cause.
+      #
+      # Installing it explicitly also pins the responsibility here rather than
+      # on whatever the image happens to ship next month.
+      - name: Install NASM (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install nasm --no-progress -y
+          $nasm = "C:\Program Files\NASM"
+          if (-not (Test-Path "$nasm\nasm.exe")) {
+            throw "NASM was not installed at $nasm"
+          }
+          Add-Content -Path $env:GITHUB_PATH -Value $nasm
+          & "$nasm\nasm.exe" -v
+
       - name: Build static PHP binary (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
@@ -237,46 +257,50 @@ jobs:
       # ── Smoke-test ──────────────────────────────────────────────────────
       - name: Smoke-test binary (Unix)
         if: runner.os != 'Windows'
-        run: ./dbdiff --version
+        run: |
+          set -euo pipefail
+          ./dbdiff --version
+
+          # --version passes even if every database driver is missing. The
+          # Windows leg builds pdo_pgsql against libpq copied out of the
+          # postgresql-win archive, and that copy has failed silently before —
+          # leaving a Postgres diff tool with no Postgres support.
+          #
+          # PDO reports a missing driver as exactly "could not find driver",
+          # and an unreachable server as a connection error, so pointing each
+          # driver at a closed port tells the two apart.
+          for scheme in postgresql mysql; do
+            out="$(./dbdiff diff \
+              --server1-url "$scheme://u:p@127.0.0.1:1/x" \
+              --server2-url "$scheme://u:p@127.0.0.1:1/y" 2>&1 || true)"
+            if printf '%s' "$out" | grep -q 'could not find driver'; then
+              echo "::error::$scheme driver missing from the binary"
+              printf '%s\n' "$out"
+              exit 1
+            fi
+            echo "$scheme driver present"
+          done
 
       - name: Smoke-test binary (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
-        run: .\dbdiff.exe --version
+        run: |
+          .\dbdiff.exe --version
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.artifact }}
-          path: dbdiff${{ startsWith(matrix.target, 'win32') && '.exe' || '' }}
-          retention-days: 1
+          # See the Unix smoke test: --version cannot tell a working binary
+          # from one built without its database drivers.
+          foreach ($scheme in @('postgresql', 'mysql')) {
+            $out = (& .\dbdiff.exe diff `
+              --server1-url "${scheme}://u:p@127.0.0.1:1/x" `
+              --server2-url "${scheme}://u:p@127.0.0.1:1/y" 2>&1 | Out-String)
+            if ($out -match 'could not find driver') {
+              Write-Output "::error::$scheme driver missing from the binary"
+              Write-Output $out
+              exit 1
+            }
+            Write-Output "$scheme driver present"
+          }
 
-  # ═══════════════════════════════════════════════════════════════════════════
-  # JOB 3 — npm dry-run publish + registry health check
-  # ═══════════════════════════════════════════════════════════════════════════
-  npm-dry-run:
-    name: "npm dry-run publish"
-    needs: [build-phar, build-binary]
-    if: ${{ !cancelled() && needs.build-phar.result == 'success' }}
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/download-artifact@v4
-        with:
-          path: binaries/
-          pattern: dbdiff-*
-          merge-multiple: false
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          registry-url: 'https://registry.npmjs.org'
-
-      # `npm publish --dry-run` never authenticates, so it can't tell us whether
-      # NPM_TOKEN is still valid. `npm whoami` makes a real authenticated call —
-      # it fails fast here if the token is missing/expired, before a real release
-      # would fail at the publish step.
       - name: Verify NPM_TOKEN is valid
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,6 +266,26 @@ jobs:
           $url = "https://github.com/crazywhalecc/static-php-cli/releases/download/${{ env.SPC_VERSION }}/spc-windows-x64.exe"
           Invoke-WebRequest -Uri $url -OutFile spc.exe
 
+      # OpenSSL's Windows build assembles with NASM. It was present on the
+      # runner image until it was not, and `spc doctor --auto-fix` only repairs
+      # the prerequisites it knows about — so it reported a clean bill of health
+      # and the build died much later with "NASM not found", inside the openssl
+      # module, with nothing pointing at the real cause.
+      #
+      # Installing it explicitly also pins the responsibility here rather than
+      # on whatever the image happens to ship next month.
+      - name: Install NASM (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install nasm --no-progress -y
+          $nasm = "C:\Program Files\NASM"
+          if (-not (Test-Path "$nasm\nasm.exe")) {
+            throw "NASM was not installed at $nasm"
+          }
+          Add-Content -Path $env:GITHUB_PATH -Value $nasm
+          & "$nasm\nasm.exe" -v
+
       - name: Build static PHP binary (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
@@ -296,50 +316,49 @@ jobs:
       # ── Smoke-test the combined binary ──────────────────────────────────────
       - name: Smoke-test binary (Unix)
         if: runner.os != 'Windows'
-        run: ./dbdiff --version
+        run: |
+          set -euo pipefail
+          ./dbdiff --version
+
+          # --version passes even if every database driver is missing. The
+          # Windows leg builds pdo_pgsql against libpq copied out of the
+          # postgresql-win archive, and that copy has failed silently before —
+          # leaving a Postgres diff tool with no Postgres support.
+          #
+          # PDO reports a missing driver as exactly "could not find driver",
+          # and an unreachable server as a connection error, so pointing each
+          # driver at a closed port tells the two apart.
+          for scheme in postgresql mysql; do
+            out="$(./dbdiff diff \
+              --server1-url "$scheme://u:p@127.0.0.1:1/x" \
+              --server2-url "$scheme://u:p@127.0.0.1:1/y" 2>&1 || true)"
+            if printf '%s' "$out" | grep -q 'could not find driver'; then
+              echo "::error::$scheme driver missing from the binary"
+              printf '%s\n' "$out"
+              exit 1
+            fi
+            echo "$scheme driver present"
+          done
 
       - name: Smoke-test binary (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
-        run: .\dbdiff.exe --version
+        run: |
+          .\dbdiff.exe --version
 
-      # ── Upload platform artifact ────────────────────────────────────────────
-      - uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.artifact }}
-          path: dbdiff${{ startsWith(matrix.target, 'win32') && '.exe' || '' }}
-          retention-days: 1
-
-  # ═══════════════════════════════════════════════════════════════════════════
-  # JOB 3 — Create GitHub Release + git tag
-  #
-  # Runs as soon as the PHAR succeeds, even if some binary builds failed.
-  # The GitHub Release is the primary distribution channel — it must never
-  # be blocked by npm registry issues (tombstones, E409 conflicts, etc.).
-  # ═══════════════════════════════════════════════════════════════════════════
-  github-release:
-    name: GitHub Release
-    needs: [build-phar, build-binary]
-    # Must check build-binary too. The matrix runs with fail-fast: false so that
-    # one broken target does not cancel the rest, which means a partial build
-    # completes "successfully" from the workflow's point of view. Gating only on
-    # build-phar published v3.0.0-rc.5 with three platforms missing (#185).
-    if: ${{ !cancelled() && needs.build-phar.result == 'success' && needs.build-binary.result == 'success' }}
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: write
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: actions/download-artifact@v4
-        with:
-          path: binaries/
-          pattern: dbdiff-*
-          merge-multiple: false
+          # See the Unix smoke test: --version cannot tell a working binary
+          # from one built without its database drivers.
+          foreach ($scheme in @('postgresql', 'mysql')) {
+            $out = (& .\dbdiff.exe diff `
+              --server1-url "${scheme}://u:p@127.0.0.1:1/x" `
+              --server2-url "${scheme}://u:p@127.0.0.1:1/y" 2>&1 | Out-String)
+            if ($out -match 'could not find driver') {
+              Write-Output "::error::$scheme driver missing from the binary"
+              Write-Output $out
+              exit 1
+            }
+            Write-Output "$scheme driver present"
+          }
 
       - name: Detect pre-release
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,11 +269,9 @@ jobs:
       # OpenSSL's Windows build assembles with NASM. It was present on the
       # runner image until it was not, and `spc doctor --auto-fix` only repairs
       # the prerequisites it knows about — so it reported a clean bill of health
-      # and the build died much later with "NASM not found", inside the openssl
-      # module, with nothing pointing at the real cause.
-      #
-      # Installing it explicitly also pins the responsibility here rather than
-      # on whatever the image happens to ship next month.
+      # and the build died much later inside the openssl module, with nothing
+      # pointing at the real cause. Unlike the musl failures this is not
+      # transient: there is nothing to retry.
       - name: Install NASM (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
@@ -320,14 +318,14 @@ jobs:
           set -euo pipefail
           ./dbdiff --version
 
-          # --version passes even if every database driver is missing. The
+          # --version passes even with no database drivers compiled in. The
           # Windows leg builds pdo_pgsql against libpq copied out of the
-          # postgresql-win archive, and that copy has failed silently before —
-          # leaving a Postgres diff tool with no Postgres support.
+          # postgresql-win archive, and those copies have failed silently
+          # before — which would ship a Postgres diff tool with no Postgres.
           #
-          # PDO reports a missing driver as exactly "could not find driver",
-          # and an unreachable server as a connection error, so pointing each
-          # driver at a closed port tells the two apart.
+          # PDO reports a missing driver as exactly "could not find driver" and
+          # an unreachable server as a connection error, so a closed port tells
+          # the two apart without needing a live database.
           for scheme in postgresql mysql; do
             out="$(./dbdiff diff \
               --server1-url "$scheme://u:p@127.0.0.1:1/x" \
@@ -359,6 +357,44 @@ jobs:
             }
             Write-Output "$scheme driver present"
           }
+
+      # ── Upload platform artifact ────────────────────────────────────────────
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: dbdiff${{ startsWith(matrix.target, 'win32') && '.exe' || '' }}
+          retention-days: 1
+
+  # ═══════════════════════════════════════════════════════════════════════════
+  # JOB 3 — Create GitHub Release + git tag
+  #
+  # Runs as soon as the PHAR succeeds, even if some binary builds failed.
+  # The GitHub Release is the primary distribution channel — it must never
+  # be blocked by npm registry issues (tombstones, E409 conflicts, etc.).
+  # ═══════════════════════════════════════════════════════════════════════════
+  github-release:
+    name: GitHub Release
+    needs: [build-phar, build-binary]
+    # Must check build-binary too. The matrix runs with fail-fast: false so that
+    # one broken target does not cancel the rest, which means a partial build
+    # completes "successfully" from the workflow's point of view. Gating only on
+    # build-phar published v3.0.0-rc.5 with three platforms missing (#185).
+    if: ${{ !cancelled() && needs.build-phar.result == 'success' && needs.build-binary.result == 'success' }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: binaries/
+          pattern: dbdiff-*
+          merge-multiple: false
 
       - name: Detect pre-release
         run: |


### PR DESCRIPTION
The `win32-x64` leg failed, which cancelled the remaining release jobs.

## The failure

```
NASM not found - make sure it's installed and available on %PATH%
Failed module: library openssl builder for Windows
```

OpenSSL's Windows build assembles with NASM. It was present on the runner image until it wasn't, and `spc doctor --auto-fix` only repairs the prerequisites it knows about — so it reported a clean bill of health and the build died much later inside the openssl module, with nothing pointing at the real cause.

**Unlike the musl failures, this is not transient.** There is nothing to retry; it would have failed identically on every attempt. Installing NASM explicitly also puts the responsibility in this repo rather than on whatever the runner image ships next month.

## The quieter problem in the same log

```
PHP Warning: copy(...\pgsql\lib\libpq.lib): No such file or directory
PHP Warning: copy(...\pgsql\include\libpq-fe.h): No such file or directory
PHP Warning: copy(...\pgsql\include\postgres_ext.h): No such file or directory
```

`pdo_pgsql` is built against libpq copied out of the `postgresql-win` archive, and every one of those copies failed. They are **warnings**, so the build carries on.

The smoke test was `dbdiff --version`, which passes whether or not a single database driver made it in. So a Postgres diff tool with **no Postgres support** would have built, smoke-tested green, and shipped.

## The check

Point each driver at a closed port. PDO distinguishes the two cases precisely, with no live database needed:

| condition | PDO says |
| --- | --- |
| driver missing | `could not find driver` |
| driver present, server unreachable | `SQLSTATE[08006] ... Connection refused` |

Confirmed against the real CLI:

```
$ dbdiff diff --server1-url "postgresql://u:p@127.0.0.1:1/x" ...
SQLSTATE[08006] [7] connection to server at "127.0.0.1", port 1 failed: Connection refused
```

Tested both directions locally — a working binary passes and exits 0; a stub emitting the missing-driver message is caught and exits 1, so CI fails rather than shipping it.

Applied to `release-dry-run.yml` too, so the dry run keeps testing what the release actually does.

## Not addressed here

The underlying reason the libpq copies fail is upstream in static-php-cli's `postgresql-win` handling. This PR makes that condition *loud* rather than fixing it — worth a separate look, but a silent driverless release is the more urgent problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)