### PR TITLE
ci: track and auto-merge @akalforge/pg-conformance updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# DBDiff is a Composer project; the only npm dependency is the shared
+# conformance data used by the Postgres conformance harness, which publishes a
+# patch on every merge to its own repository.
+#
+# `npm ci` installs strictly from the lockfile and ignores the range in
+# package.json, so something has to move the lockfile for a published release
+# to reach this repository at all. That is this.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+    allow:
+      - dependency-name: "@akalforge/pg-conformance"
+    commit-message:
+      prefix: chore
+      include: scope
+    labels:
+      - dependencies
+    open-pull-requests-limit: 3

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,38 @@
+name: Auto-merge conformance updates
+
+# Turns a published patch of @akalforge/pg-conformance into a merged lockfile
+# bump without anyone doing anything — while keeping `npm ci` reproducible,
+# which is the whole reason the lockfile has to move at all.
+#
+# Nothing is merged blind. `--auto` waits for every required check, so a
+# conformance release that broke this consumer would leave the pull request
+# open and red rather than landing.
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Inspect the update
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Scoped twice over: dependabot.yml already limits what gets opened, and
+      # this refuses anything else that reaches here. A workflow that merges
+      # whatever dependabot proposes is a supply-chain hole, not a convenience.
+      - name: Enable auto-merge for patch updates to the shared corpus
+        if: >-
+          steps.meta.outputs.dependency-names == '@akalforge/pg-conformance' &&
+          steps.meta.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes the loop on the shared conformance data introduced in #196.

## Why this is needed

`npm ci` installs **strictly from the lockfile** and ignores the range in `package.json`. So the shared package auto-publishing patches, plus `~0.0.1` here, achieves nothing on its own — the release succeeds and reaches nobody. Something has to move the lockfile, and dropping `npm ci` would trade reproducible installs for it.

## Dependabot, not Renovate

Renovate needs a GitHub App installed against the org. Dependabot is already available and does the same job here. **Allow auto-merge** also had to be enabled on the repo — that is a permission that lets a PR be *marked* merge-on-green, not a behaviour that merges anything by itself.

## Scoped twice, deliberately

`dependabot.yml` allows only `@akalforge/pg-conformance` — the sole npm dependency in what is otherwise a Composer project — and the workflow independently refuses anything else that reaches it.

Only **patch** updates auto-merge. A minor or major means the fingerprint changed shape, which is exactly when a human should look.

## Nothing merges blind

`--auto` waits for every required check, including the conformance matrix across PostgreSQL 16, 17 and 18. An update that broke this harness leaves the PR open and red rather than landing — and the upstream package already tests itself against PostgreSQL 14–18 before publishing, so a bad patch has to get past both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)