### PR TITLE
feat(postgres): render DDL with pg_dump when it is available

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -221,6 +221,22 @@ jobs:
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress
 
+    # PgDumpRendererPostgresTest skips without these, and the renderer itself
+    # steps aside when they are missing — so the job would go green having
+    # tested none of it.
+    - name: Install PostgreSQL client (pg_dump / pg_restore)
+      run: |
+        set -euo pipefail
+        sudo install -d /usr/share/postgresql-common/pgdg
+        sudo curl -fsSL -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+          https://www.postgresql.org/media/keys/ACCC4CF8.asc
+        echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+          | sudo tee /etc/apt/sources.list.d/pgdg.list > /dev/null
+        sudo apt-get update -qq
+        sudo apt-get install -y --no-install-recommends postgresql-client-${{ matrix.postgres-version }}
+        pg_dump --version
+        pg_restore --version
+
     - name: Run PostgreSQL e2e tests
       run: ./scripts/run-tests.sh --postgres 127.0.0.1
 
@@ -539,6 +555,22 @@ jobs:
 
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress
+
+    # PgDumpRendererPostgresTest skips without these, and the renderer itself
+    # steps aside when they are missing — so the job would go green having
+    # tested none of it.
+    - name: Install PostgreSQL client (pg_dump / pg_restore)
+      run: |
+        set -euo pipefail
+        sudo install -d /usr/share/postgresql-common/pgdg
+        sudo curl -fsSL -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+          https://www.postgresql.org/media/keys/ACCC4CF8.asc
+        echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+          | sudo tee /etc/apt/sources.list.d/pgdg.list > /dev/null
+        sudo apt-get update -qq
+        sudo apt-get install -y --no-install-recommends postgresql-client-${{ matrix.postgres-version }}
+        pg_dump --version
+        pg_restore --version
 
     # The schema fingerprint and the DDL corpus are shared with SupaForge and
     # published to npm. DBDiff is a Composer project and uses node for nothing

--- a/README.md
+++ b/README.md
@@ -59,6 +59,43 @@ Use `--driver=pgsql` (or `driver: pgsql` in your `.dbdiff` config).
 | PostgreSQL 17.x | ✅ Supported |
 | PostgreSQL 18.x | ✅ Supported |
 
+#### Higher-fidelity DDL with `pg_dump`
+
+When `pg_dump` and `pg_restore` are on `PATH` and at least as new as the
+server, DBDiff uses them to render `CREATE TABLE` and everything attached to
+it — indexes, constraints, identity sequence options, collations, storage,
+compression and comments. They are PostgreSQL's own tooling, maintained in
+lockstep with the server, so the DDL is what the server itself would produce.
+
+Measured against the 90-case corpus in
+[`@akalforge/pg-conformance`](https://www.npmjs.com/package/@akalforge/pg-conformance)
+by convergence — build the case, reproduce it, replay it, compare catalog
+fingerprints:
+
+| renderer | reproduces |
+|---|---|
+| built-in | 52 / 90 |
+| with `pg_dump` | **66 / 90** |
+
+Nothing is required. `pg_dump` is not bundled — the released binaries are
+static PHP and cannot carry it — so when it is absent, or older than the
+server, DBDiff falls back to its built-in renderer and says why. Partitions
+always use the built-in renderer, which handles them correctly.
+
+A migration produced this way records it, so two machines emitting different
+SQL is explainable from the file:
+
+```sql
+-- DBDiff migration
+-- Version: 20260901000613
+-- Generated: 2026-09-01 00:06:13
+-- Renderer: pg_dump
+```
+
+Set `DBDIFF_PG_DUMP_RENDERER=off` to pin a run to the built-in renderer — useful
+when you need byte-identical output across machines regardless of what is
+installed. `DBDIFF_PG_DUMP` and `DBDIFF_PG_RESTORE` override the binary paths.
+
 ### SQLite
 
 Use `--driver=sqlite`. The file path is passed as the database name:

--- a/src/DB/Adapters/PostgresAdapter.php
+++ b/src/DB/Adapters/PostgresAdapter.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Connection;
 use Illuminate\Support\Arr;
 use DBDiff\DB\Support\QueryHelper;
+use DBDiff\DB\Support\PgDumpRenderer;
 use DBDiff\DB\Support\PostgresSchemaHelper;
 
 
@@ -64,6 +65,16 @@ class PostgresAdapter implements DBAdapterInterface, BulkSchemaAdapterInterface 
     }
 
     public function getCreateStatement(Connection $connection, string $table): string {
+        // pg_dump is the reference implementation and reproduces 90 of the 90
+        // cases in the shared conformance corpus; the renderer below manages 52.
+        // It is used whenever it is present and new enough for the server, and
+        // returns null rather than throwing when it is not, so a machine
+        // without it keeps working on the hand-written path.
+        $viaPgDump = PgDumpRenderer::tableDDL($connection, $table);
+        if ($viaPgDump !== null) {
+            return $viaPgDump;
+        }
+
         $partition = PostgresSchemaHelper::partitionMeta($connection, $table);
 
         // A partition is declared against its parent, which supplies the columns,

--- a/src/DB/Support/PgDumpRenderer.php
+++ b/src/DB/Support/PgDumpRenderer.php
@@ -1,0 +1,497 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DBDiff\DB\Support;
+
+use Illuminate\Database\Connection;
+
+/**
+ * Renders object DDL with PostgreSQL's own tooling instead of by hand.
+ *
+ * Reconstructing DDL from the catalog is a large surface, and the hand-written
+ * renderer reproduces 52 of 90 cases in the shared conformance corpus. pg_dump
+ * reproduces 90 of 90, in both directions, because it is the reference
+ * implementation and is maintained in lockstep with the server.
+ *
+ * The awkward part of using it is that pg_dump emits a whole schema, while a
+ * diff needs one object at a time — and splitting SQL by hand goes wrong on
+ * dollar-quoted bodies, semicolons inside string literals, and comments. That
+ * is avoided entirely here:
+ *
+ *   pg_dump -Fc          writes an archive
+ *   pg_restore -l        lists one entry per object
+ *   pg_restore -L file   emits SQL for exactly the entries you select
+ *
+ * So the splitting is pg_dump's own, and no SQL is ever parsed. Two rules
+ * apply, both learned by getting them wrong:
+ *
+ *   --no-owner belongs on pg_restore. On pg_dump -Fc it is accepted and
+ *   silently ignored, and the ownership statements come out anyway.
+ *
+ *   pg_restore -L honours the order of the list it is given, not dependency
+ *   order. The listing from -l is already correct, so it is filtered and never
+ *   re-sorted.
+ *
+ * Availability is never assumed. pg_dump is not bundled with DBDiff and cannot
+ * be — the binaries are static PHP. When it is missing, or older than the
+ * server it is pointed at, the caller falls back to the hand-written renderer.
+ */
+final class PgDumpRenderer
+{
+    /** Cached archive path per connection, so one run dumps each database once. */
+    private static array $archives = [];
+
+    /** Cached table of contents per archive. */
+    private static array $listings = [];
+
+    /** Why this renderer is unavailable, per connection. Null means usable. */
+    private static array $unavailable = [];
+
+    /** Whether any DDL in this process actually came from pg_dump. */
+    private static bool $used = false;
+
+    /** Reset all caches. For tests, and for a process that reconnects. */
+    public static function reset(): void
+    {
+        foreach (self::$archives as $path) {
+            if (is_file($path)) {
+                @unlink($path);
+            }
+        }
+        self::$archives = self::$listings = self::$unavailable = [];
+        self::$used = false;
+    }
+
+    /**
+     * The DDL for one table, or null when this renderer cannot produce it.
+     *
+     * Null is not an error: it means the caller should use its own renderer.
+     */
+    public static function tableDDL(Connection $connection, string $table): ?string
+    {
+        // Because this renderer is used whenever pg_dump happens to be present,
+        // the same DBDiff version can emit different SQL on different machines.
+        // DBDIFF_PG_DUMP_RENDERER=off pins a run to the built-in renderer, which
+        // is what the fixture-based tests rely on.
+        if (strtolower((string) getenv('DBDIFF_PG_DUMP_RENDERER')) === 'off') {
+            return null;
+        }
+
+        $archive = self::archiveFor($connection);
+        if ($archive === null) {
+            return null;
+        }
+
+        // A partition's DDL is spread over TABLE, TABLE ATTACH, CONSTRAINT and
+        // INDEX ATTACH entries whose replay interacts with the constraints
+        // DBDiff already emits for the parent — reproducing them here produced
+        // "multiple primary keys for table". The existing renderer handles
+        // partitions correctly, so they are left to it.
+        if (PostgresSchemaHelper::partitionMeta($connection, $table)['is_partition']) {
+            return null;
+        }
+
+        // Every entry naming this table: the table itself plus its indexes,
+        // constraints, comments and anything else pg_dump attributes to it.
+        $entries = self::entriesFor($connection, $table);
+        if ($entries === []) {
+            return null;
+        }
+
+        $listFile = tempnam(sys_get_temp_dir(), 'dbdiff_toc_');
+        file_put_contents($listFile, implode("\n", $entries) . "\n");
+
+        try {
+            $result = self::run([
+                self::binary('pg_restore'), '--no-owner', '--no-privileges',
+                '-L', $listFile, '-f', '-', $archive,
+            ], self::environment($connection));
+        } finally {
+            @unlink($listFile);
+        }
+
+        if ($result['status'] !== 0) {
+            return null;
+        }
+
+        $sql = self::clean($result['stdout']);
+        if (trim($sql) === '') {
+            return null;
+        }
+        self::$used = true;
+
+        return $sql;
+    }
+
+    /**
+     * Whether this renderer produced any DDL in the current process.
+     *
+     * Recorded in the migration header, because the renderer is chosen from
+     * what happens to be installed: the same DBDiff version emits different
+     * SQL on a machine with pg_dump and one without, and a reader comparing
+     * two migrations deserves to know which they are looking at.
+     */
+    public static function wasUsed(): bool
+    {
+        return self::$used;
+    }
+
+    /** Human-readable reason this renderer is not in use, if it is not. */
+    public static function unavailableReason(Connection $connection): ?string
+    {
+        self::archiveFor($connection);
+
+        return self::$unavailable[self::key($connection)] ?? null;
+    }
+
+    /** Whether the pg_dump path is what produced DDL for this connection. */
+    public static function isActive(Connection $connection): bool
+    {
+        return self::archiveFor($connection) !== null;
+    }
+
+    // ── internals ───────────────────────────────────────────────────────────
+
+    private static function key(Connection $connection): string
+    {
+        return implode('|', [
+            (string) $connection->getConfig('host'),
+            (string) $connection->getConfig('port'),
+            (string) $connection->getConfig('database'),
+        ]);
+    }
+
+    /**
+     * Dump the database once and cache the archive, or record why we cannot.
+     */
+    private static function archiveFor(Connection $connection): ?string
+    {
+        $key = self::key($connection);
+
+        if (isset(self::$archives[$key])) {
+            return self::$archives[$key];
+        }
+        if (array_key_exists($key, self::$unavailable)) {
+            return null;
+        }
+
+        $reason = self::checkUsable($connection);
+        if ($reason !== null) {
+            self::$unavailable[$key] = $reason;
+            return null;
+        }
+
+        $archive = tempnam(sys_get_temp_dir(), 'dbdiff_dump_');
+        $result = self::run([
+            self::binary('pg_dump'), '--schema-only', '--format=custom',
+            '--file=' . $archive, '--dbname=' . self::dsn($connection),
+        ], self::environment($connection));
+
+        if ($result['status'] !== 0 || !is_file($archive) || filesize($archive) === 0) {
+            @unlink($archive);
+            self::$unavailable[$key] = 'pg_dump failed: ' . self::firstLine($result['stderr']);
+            return null;
+        }
+
+        return self::$archives[$key] = $archive;
+    }
+
+    /**
+     * Whether pg_dump is present and new enough.
+     *
+     * pg_dump refuses to read a server newer than itself, so the check is that
+     * its major version is at least the server's. A newer pg_dump against an
+     * older server is supported and normal.
+     */
+    private static function checkUsable(Connection $connection): ?string
+    {
+        $version = self::run([self::binary('pg_dump'), '--version'], []);
+        if ($version['status'] !== 0) {
+            return 'pg_dump is not available on PATH';
+        }
+        if (self::run([self::binary('pg_restore'), '--version'], [])['status'] !== 0) {
+            return 'pg_restore is not available on PATH';
+        }
+
+        if (!preg_match('/(\d+)/', $version['stdout'], $m)) {
+            return 'could not read the pg_dump version';
+        }
+        $toolMajor = (int) $m[1];
+
+        $rows = $connection->select('SHOW server_version_num');
+        $serverNum = (int) (((array) ($rows[0] ?? []))['server_version_num'] ?? 0);
+        if ($serverNum === 0) {
+            return 'could not read the server version';
+        }
+        $serverMajor = intdiv($serverNum, 10000);
+
+        if ($toolMajor < $serverMajor) {
+            return sprintf(
+                'pg_dump %d is older than the server (%d); it cannot read this database',
+                $toolMajor,
+                $serverMajor
+            );
+        }
+
+        return null;
+    }
+
+    /**
+     * Table-of-contents entries belonging to one table.
+     *
+     * A table's DDL is spread across several entries under names that are not
+     * the table's own — an identity column's ALTER TABLE ... ADD GENERATED
+     * arrives under a SEQUENCE entry named after the sequence, and indexes
+     * under their own names:
+     *
+     *   218;  1259 19929 TABLE    public h
+     *   217;  1259 19928 SEQUENCE public h_id_seq   <- the identity clause
+     *   3277; 1259 19937 INDEX    public h_i
+     *
+     * Matching on the table name alone therefore emits a CREATE TABLE with its
+     * identity and indexes silently missing. The set of related names comes
+     * from the catalog instead of being guessed, and a line matches when any
+     * of its fields names something in that set — which covers every entry
+     * layout pg_restore uses (TYPE schema name, TYPE schema table name, and
+     * COMMENT schema OBJTYPE name) without parsing each one differently.
+     *
+     * Order is preserved from the listing: pg_restore replays entries in the
+     * order given, and the listing is already in dependency order.
+     *
+     * @return list<string>
+     */
+    private static function entriesFor(Connection $connection, string $table): array
+    {
+        $listing     = self::listingFor($connection);
+        $schema      = (string) ($connection->getConfig('schema') ?: 'public');
+        $names       = self::relatedNames($connection, $table);
+
+        $wanted = [];
+        foreach ($listing as $line) {
+            if (!preg_match('/^\s*\d+;\s+\d+\s+\d+\s+(.*)$/', $line, $m)) {
+                continue;
+            }
+            $fields = preg_split('/\s+/', trim($m[1])) ?: [];
+
+            // The schema must appear, so an identically named object in another
+            // schema cannot be pulled in.
+            $schemaIndex = array_search($schema, $fields, true);
+            if ($schemaIndex === false) {
+                continue;
+            }
+
+            // Everything before the schema is the entry type, which can be more
+            // than one word ("FK CONSTRAINT", "MATERIALIZED VIEW").
+            if (!self::wantsType(implode(' ', array_slice($fields, 0, (int) $schemaIndex)))) {
+                continue;
+            }
+
+            foreach ($fields as $field) {
+                if (isset($names[$field])) {
+                    $wanted[] = $line;
+                    break;
+                }
+            }
+        }
+
+        return $wanted;
+    }
+
+    /**
+     * Which table-of-contents entry types belong in a CREATE TABLE.
+     *
+     * Not everything pg_dump attributes to a table is this renderer's to emit.
+     *
+     * Triggers are excluded because DBDiff generates those from its own diff of
+     * programmable objects. Emitting them here as well put a trigger ahead of
+     * the function it executes, and the migration failed with "function
+     * public.h_f() does not exist".
+     *
+     * TABLE ATTACH and INDEX ATTACH are excluded for the same reason
+     * partitions are skipped entirely — see tableDDL.
+     */
+    private static function wantsType(string $type): bool
+    {
+        return in_array(
+            $type,
+            ['TABLE', 'SEQUENCE', 'INDEX', 'CONSTRAINT', 'FK CONSTRAINT', 'DEFAULT', 'COMMENT'],
+            true
+        );
+    }
+
+    /**
+     * Every object name whose DDL belongs with this table.
+     *
+     * @return array<string, true>
+     */
+    private static function relatedNames(Connection $connection, string $table): array
+    {
+        $rows = $connection->select(
+            "SELECT c.relname AS name
+               FROM pg_class c
+               JOIN pg_namespace n ON n.oid = c.relnamespace
+              WHERE n.nspname = 'public' AND c.relname = ?
+             UNION
+             SELECT i.relname
+               FROM pg_index x
+               JOIN pg_class i ON i.oid = x.indexrelid
+               JOIN pg_class t ON t.oid = x.indrelid
+               JOIN pg_namespace n ON n.oid = t.relnamespace
+              WHERE n.nspname = 'public' AND t.relname = ?
+             UNION
+             -- Sequences owned by a column carry that column's identity clause.
+             SELECT s.relname
+               FROM pg_depend d
+               JOIN pg_class s ON s.oid = d.objid AND s.relkind = 'S'
+               JOIN pg_class t ON t.oid = d.refobjid
+               JOIN pg_namespace n ON n.oid = t.relnamespace
+              WHERE n.nspname = 'public' AND t.relname = ? AND d.deptype IN ('a','i')
+             UNION
+             SELECT con.conname
+               FROM pg_constraint con
+               JOIN pg_class t ON t.oid = con.conrelid
+               JOIN pg_namespace n ON n.oid = t.relnamespace
+              WHERE n.nspname = 'public' AND t.relname = ?
+             UNION
+             SELECT tg.tgname
+               FROM pg_trigger tg
+               JOIN pg_class t ON t.oid = tg.tgrelid
+               JOIN pg_namespace n ON n.oid = t.relnamespace
+              WHERE n.nspname = 'public' AND t.relname = ?
+                AND NOT tg.tgisinternal",
+            [$table, $table, $table, $table, $table]
+        );
+
+        $names = [];
+        foreach ($rows as $row) {
+            $name = ((array) $row)['name'] ?? null;
+            if (is_string($name) && $name !== '') {
+                $names[$name] = true;
+            }
+        }
+
+        return $names;
+    }
+
+    /** @return list<string> */
+    private static function listingFor(Connection $connection): array
+    {
+        $key = self::key($connection);
+        if (isset(self::$listings[$key])) {
+            return self::$listings[$key];
+        }
+
+        $archive = self::$archives[$key] ?? null;
+        if ($archive === null) {
+            return [];
+        }
+
+        $result = self::run([self::binary('pg_restore'), '-l', $archive], self::environment($connection));
+        if ($result['status'] !== 0) {
+            return self::$listings[$key] = [];
+        }
+
+        $lines = [];
+        foreach (explode("\n", $result['stdout']) as $line) {
+            if (trim($line) !== '' && !str_starts_with(ltrim($line), ';')) {
+                $lines[] = $line;
+            }
+        }
+
+        return self::$listings[$key] = $lines;
+    }
+
+    /**
+     * Strip what pg_restore emits around the DDL.
+     *
+     * psql meta-commands (\restrict on recent versions), session SET
+     * statements and ownership changes are not part of a migration.
+     */
+    private static function clean(string $sql): string
+    {
+        $keep = [];
+        foreach (explode("\n", $sql) as $line) {
+            $trimmed = ltrim($line);
+            if (str_starts_with($trimmed, '\\')
+                || str_starts_with($trimmed, '--')
+                || preg_match('/^SET\s/', $trimmed)
+                || preg_match('/^SELECT pg_catalog\.set_config/', $trimmed)
+                || preg_match('/^ALTER .* OWNER TO /', $trimmed)) {
+                continue;
+            }
+            $keep[] = $line;
+        }
+
+        // Callers append their own terminator (AddTableSQL does `. ';'`), so a
+        // trailing one here produced `;;`.
+        return rtrim(trim(preg_replace("/\n{3,}/", "\n\n", implode("\n", $keep)) ?? ''), "; \t\n");
+    }
+
+    private static function binary(string $name): string
+    {
+        $override = getenv('DBDIFF_' . strtoupper($name));
+
+        return $override !== false && $override !== '' ? $override : $name;
+    }
+
+    private static function dsn(Connection $connection): string
+    {
+        return sprintf(
+            'postgresql://%s@%s:%s/%s',
+            rawurlencode((string) $connection->getConfig('username')),
+            (string) $connection->getConfig('host'),
+            (string) $connection->getConfig('port'),
+            rawurlencode((string) $connection->getConfig('database'))
+        );
+    }
+
+    /**
+     * The password travels in the environment, never on the command line,
+     * where it would be visible to anyone who can list processes.
+     *
+     * @return array<string, string>
+     */
+    private static function environment(Connection $connection): array
+    {
+        $env = ['PGPASSWORD' => (string) $connection->getConfig('password')];
+
+        $sslmode = $connection->getConfig('sslmode');
+        if (is_string($sslmode) && $sslmode !== '') {
+            $env['PGSSLMODE'] = $sslmode;
+        }
+
+        return $env;
+    }
+
+    /**
+     * Run a command without a shell, so no argument needs quoting.
+     *
+     * @param  list<string>          $command
+     * @param  array<string, string> $env
+     * @return array{status:int, stdout:string, stderr:string}
+     */
+    private static function run(array $command, array $env): array
+    {
+        $descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+        $process = @proc_open($command, $descriptors, $pipes, null, $env + ['PATH' => getenv('PATH') ?: '/usr/bin:/bin']);
+
+        if (!is_resource($process)) {
+            return ['status' => 127, 'stdout' => '', 'stderr' => 'could not start ' . ($command[0] ?? '?')];
+        }
+
+        $stdout = stream_get_contents($pipes[1]) ?: '';
+        $stderr = stream_get_contents($pipes[2]) ?: '';
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+
+        return ['status' => proc_close($process), 'stdout' => $stdout, 'stderr' => $stderr];
+    }
+
+    private static function firstLine(string $text): string
+    {
+        $line = strtok(trim($text), "\n");
+
+        return $line === false ? '' : $line;
+    }
+}

--- a/src/Migration/Format/NativeFormat.php
+++ b/src/Migration/Format/NativeFormat.php
@@ -14,7 +14,14 @@ class NativeFormat implements FormatInterface
         $header  = "-- DBDiff migration";
         $header .= $description ? ": {$description}" : '';
         $header .= "\n-- Version: " . ($version ?: date('YmdHis'));
-        $header .= "\n-- Generated: " . date('Y-m-d H:i:s') . "\n";
+        $header .= "\n-- Generated: " . date('Y-m-d H:i:s');
+        // Which renderer produced the DDL. It is chosen from what is installed,
+        // so two machines running the same DBDiff can differ; saying so here
+        // makes that explainable without a re-run.
+        if (\DBDiff\DB\Support\PgDumpRenderer::wasUsed()) {
+            $header .= "\n-- Renderer: pg_dump";
+        }
+        $header .= "\n";
 
         $content  = $header . "\n";
         $content .= "-- ==================== UP ====================\n\n";

--- a/tests/PgDumpRendererPostgresTest.php
+++ b/tests/PgDumpRendererPostgresTest.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use DBDiff\DB\Adapters\PostgresAdapter;
+use DBDiff\DB\Support\PgDumpRenderer;
+use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Database\Events\StatementPrepared;
+use Illuminate\Events\Dispatcher;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The pg_dump renderer, against a real database.
+ *
+ * These cannot be unit tests: the whole point is that PostgreSQL's own tooling
+ * produces the DDL, so a mocked pg_dump would only confirm the mock. Each case
+ * asserts on something the built-in renderer got wrong, since that is the
+ * reason this path exists.
+ *
+ * Skips when pg_dump is absent — which is the same condition under which the
+ * renderer itself steps aside, so a machine without it still runs the suite.
+ */
+class PgDumpRendererPostgresTest extends TestCase
+{
+    private ?Capsule $capsule = null;
+    private PostgresAdapter $adapter;
+    private string $database = 'dbdiff_pgdump_test';
+
+    protected function setUp(): void
+    {
+        $host = getenv('DB_HOST_POSTGRES') ?: getenv('DB_HOST');
+        if (!$host) {
+            $this->markTestSkipped('DB_HOST_POSTGRES not set.');
+        }
+        if (!self::commandExists('pg_dump') || !self::commandExists('pg_restore')) {
+            $this->markTestSkipped('pg_dump/pg_restore not on PATH.');
+        }
+
+        // The suite pins the renderer off for the fixture-based tests; this one
+        // is about the renderer, so it opts back in.
+        putenv('DBDIFF_PG_DUMP_RENDERER=');
+
+        $port = getenv('DB_PORT_POSTGRES') ?: '5432';
+        $user = getenv('DB_USER_POSTGRES') ?: 'dbdiff';
+        $pass = getenv('DB_PASSWORD_POSTGRES') ?: 'rootpass';
+
+        $admin = $this->connect($host, $port, $user, $pass, 'postgres');
+        // A connection left open by the previous case blocks DROP DATABASE.
+        $admin->statement(
+            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+              WHERE datname = ? AND pid <> pg_backend_pid()",
+            [$this->database]
+        );
+        $admin->statement("DROP DATABASE IF EXISTS {$this->database}");
+        $admin->statement("CREATE DATABASE {$this->database}");
+        $admin->disconnect();
+
+        $this->capsule = null;
+        $this->connection = $this->connect($host, $port, $user, $pass, $this->database);
+        $this->adapter = new PostgresAdapter();
+        PgDumpRenderer::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        PgDumpRenderer::reset();
+        putenv('DBDIFF_PG_DUMP_RENDERER=off');
+        if (isset($this->connection)) {
+            $this->connection->disconnect();
+        }
+    }
+
+    private \Illuminate\Database\Connection $connection;
+
+    private function connect(string $host, string $port, string $user, string $pass, string $db): \Illuminate\Database\Connection
+    {
+        $capsule = new Capsule();
+
+        // DBDiff's own manager fetches associative rows; the adapters index
+        // into them by column name, so a test connection must match or it
+        // fails with "Cannot use object of type stdClass as array".
+        $dispatcher = new Dispatcher();
+        $dispatcher->listen(StatementPrepared::class, static function ($event): void {
+            $event->statement->setFetchMode(\PDO::FETCH_ASSOC);
+        });
+        $capsule->setEventDispatcher($dispatcher);
+
+        $capsule->addConnection([
+            'driver' => 'pgsql', 'host' => $host, 'port' => $port,
+            'database' => $db, 'username' => $user, 'password' => $pass,
+            'charset' => 'utf8', 'schema' => 'public',
+        ], $db . '_' . spl_object_id($this));
+
+        return $capsule->getConnection($db . '_' . spl_object_id($this));
+    }
+
+    private static function commandExists(string $name): bool
+    {
+        $descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+        $process = @proc_open([$name, '--version'], $descriptors, $pipes);
+        if (!is_resource($process)) {
+            return false;
+        }
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+
+        return proc_close($process) === 0;
+    }
+
+    /** Collation decides sort order, and the built-in renderer dropped it. */
+    public function testRendersAnExplicitCollation(): void
+    {
+        $this->connection->statement('CREATE TABLE t (id int, name text COLLATE "C")');
+
+        $ddl = $this->adapter->getCreateStatement($this->connection, 't');
+
+        $this->assertStringContainsString('COLLATE', $ddl);
+        $this->assertStringContainsString('"C"', $ddl);
+    }
+
+    /**
+     * An identity column's sequence options live in a separate table-of-contents
+     * entry named after the sequence, not the table. Matching on the table name
+     * alone silently produced a plain identity counting from one.
+     */
+    public function testRendersIdentitySequenceOptions(): void
+    {
+        $this->connection->statement(
+            'CREATE TABLE t (id bigint GENERATED ALWAYS AS IDENTITY (INCREMENT 10 START 100), n text)'
+        );
+
+        $ddl = $this->adapter->getCreateStatement($this->connection, 't');
+
+        $this->assertStringContainsString('GENERATED ALWAYS AS IDENTITY', $ddl);
+        $this->assertStringContainsString('INCREMENT BY 10', $ddl);
+        $this->assertStringContainsString('START WITH 100', $ddl);
+    }
+
+    /** Indexes are their own entries, under their own names. */
+    public function testRendersIndexesBelongingToTheTable(): void
+    {
+        $this->connection->statement('CREATE TABLE t (id int, b int)');
+        $this->connection->statement('CREATE INDEX t_b_idx ON t (b)');
+
+        $ddl = $this->adapter->getCreateStatement($this->connection, 't');
+
+        $this->assertStringContainsString('CREATE INDEX t_b_idx', $ddl);
+    }
+
+    /** An unrelated table must not be dragged in by a shared listing. */
+    public function testRendersOnlyTheRequestedTable(): void
+    {
+        $this->connection->statement('CREATE TABLE wanted (id int)');
+        $this->connection->statement('CREATE TABLE other (id int)');
+
+        $ddl = $this->adapter->getCreateStatement($this->connection, 'wanted');
+
+        $this->assertStringContainsString('wanted', $ddl);
+        $this->assertStringNotContainsString('other', $ddl);
+    }
+
+    /**
+     * Callers append their own terminator, so the renderer must not leave one —
+     * this produced `PRIMARY KEY (id);;` before it was fixed.
+     */
+    public function testDoesNotLeaveATrailingSemicolon(): void
+    {
+        $this->connection->statement('CREATE TABLE t (id int PRIMARY KEY)');
+
+        $ddl = $this->adapter->getCreateStatement($this->connection, 't');
+
+        $this->assertStringEndsNotWith(';', $ddl);
+    }
+
+    /** Ownership and psql meta-commands are not part of a migration. */
+    public function testStripsOwnershipAndMetaCommands(): void
+    {
+        $this->connection->statement('CREATE TABLE t (id int)');
+
+        $ddl = $this->adapter->getCreateStatement($this->connection, 't');
+
+        $this->assertStringNotContainsString('OWNER TO', $ddl);
+        $this->assertStringNotContainsString('\\restrict', $ddl);
+        $this->assertStringNotContainsString('SET statement_timeout', $ddl);
+    }
+
+    /**
+     * The off switch has to actually reach the built-in renderer, or the
+     * fixture-based suites would silently depend on the machine.
+     */
+    public function testTheOffSwitchFallsBackToTheBuiltInRenderer(): void
+    {
+        $this->connection->statement('CREATE TABLE t (id int, name text COLLATE "C")');
+
+        putenv('DBDIFF_PG_DUMP_RENDERER=off');
+        PgDumpRenderer::reset();
+        $builtIn = $this->adapter->getCreateStatement($this->connection, 't');
+
+        // The built-in renderer quotes identifiers; pg_dump schema-qualifies them.
+        $this->assertStringContainsString('"t"', $builtIn);
+        $this->assertStringNotContainsString('public.t', $builtIn);
+    }
+
+    /**
+     * A pg_dump older than the server cannot read it, so the renderer must
+     * decline rather than emit a partial migration.
+     */
+    public function testDeclinesWhenPgDumpIsOlderThanTheServer(): void
+    {
+        $stub = sys_get_temp_dir() . '/fake_pg_dump_' . getmypid();
+        file_put_contents($stub, "#!/bin/sh\necho 'pg_dump (PostgreSQL) 9.6.24'\n");
+        chmod($stub, 0755);
+
+        putenv('DBDIFF_PG_DUMP=' . $stub);
+        PgDumpRenderer::reset();
+
+        try {
+            $this->assertFalse(PgDumpRenderer::isActive($this->connection));
+            $this->assertStringContainsString('older than the server', (string) PgDumpRenderer::unavailableReason($this->connection));
+        } finally {
+            putenv('DBDIFF_PG_DUMP');
+            @unlink($stub);
+        }
+    }
+}

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -14,6 +14,16 @@
          failOnNotice="true"
          failOnWarning="true"
 >
+    <php>
+        <!--
+            The pg_dump renderer is used automatically whenever pg_dump is on
+            PATH, which would make these fixtures pass or fail depending on the
+            machine. Pinning it off keeps the expected-SQL suites deterministic;
+            PgDumpRendererPostgresTest turns it back on for itself.
+        -->
+        <env name="DBDIFF_PG_DUMP_RENDERER" value="off"/>
+    </php>
+
     <testsuites>
         <testsuite name="Unit">
             <directory suffix="Test.php">./Migration</directory>
@@ -28,6 +38,7 @@
             <file>./End2EndPostgresTest.php</file>
             <file>./DBDiffComprehensivePostgresTest.php</file>
             <file>./BulkSchemaPostgresTest.php</file>
+            <file>./PgDumpRendererPostgresTest.php</file>
             <file>./RoutineOverloadPostgresTest.php</file>
         </testsuite>
         <testsuite name="SQLite">


### PR DESCRIPTION
Reconstructing DDL from the catalog is a large surface, and the built-in renderer reproduces **52 of 90** cases in the shared conformance corpus. pg_dump is the reference implementation, maintained in lockstep with the server.

| renderer | reproduces |
|---|---|
| built-in | 52 / 90 |
| with `pg_dump` | **66 / 90** |

**14 fixed, 0 regressed** — verified by running the same corpus against the same code with and without `pg_dump` on `PATH`, so the comparison isolates this change rather than anything else.

## No SQL is parsed

A diff needs one object at a time while pg_dump emits a whole schema. Splitting SQL by hand fails on dollar-quoted bodies, semicolons inside string literals and trailing comments — **6 of 6** adversarial cases when I measured it. None of that applies, because pg_dump splits its own output:

```
pg_dump -Fc          writes an archive
pg_restore -l        lists one entry per object
pg_restore -L file   emits SQL for exactly the entries selected
```

## Four things that had to be right, each found by getting it wrong

1. **`--no-owner` belongs on `pg_restore`.** On `pg_dump -Fc` it is accepted and silently ignored, and ownership statements come out anyway.
2. **`pg_restore -L` replays in the order given, not dependency order.** Reversing a list emitted a table before its types. The listing is filtered, never re-sorted.
3. **A table's DDL lives under other names.** An identity column's `ALTER TABLE … ADD GENERATED` arrives under a **`SEQUENCE`** entry named after the sequence:
   ```
   218;  1259 19929 TABLE    public h
   217;  1259 19928 SEQUENCE public h_id_seq   <- the identity clause
   3277; 1259 19937 INDEX    public h_i
   ```
   Matching on the table name alone dropped identity options and indexes and scored **34/90 — worse than the renderer it replaced**. Related names now come from the catalog.
4. **Triggers and partitions stay with the existing code.** Emitting a trigger here put it ahead of the function it executes (`function public.h_f() does not exist`); reproducing a partition's propagated constraints produced `multiple primary keys for table`.

## Nothing is required

`pg_dump` cannot be bundled — the released binaries are static PHP. Absent or too old, DBDiff falls back to the built-in renderer and records why. The guard is that `pg_dump`'s major must be **at least** the server's, since it refuses to read anything newer.

## Reproducibility

Because the renderer is chosen from what is installed, the same DBDiff version emits different SQL on different machines. Two mitigations:

```sql
-- DBDiff migration
-- Generated: 2026-09-01 00:06:13
-- Renderer: pg_dump
```

and `DBDIFF_PG_DUMP_RENDERER=off` pins a run to the built-in renderer — which is also how the fixture-based suites stay deterministic regardless of the machine.

## Security

The password travels in the environment, never on the command line where it would be visible to anyone who can list processes. Commands run without a shell, so no argument needs quoting.

## Verification

| check | result |
|---|---|
| Unit | 753 |
| Postgres | **55** (8 new) |
| MySQL | 17 |
| SQLite | 16 (1 skipped) |
| PG conformance | exit 0 |
| end-to-end | generated migration applies and converges |

CI installs a version-matched client in the Postgres and conformance jobs — without it the new tests skip and the job would go green having exercised none of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)