### PR TITLE
test(pgdump): prove the renderer under test is the one that ran

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -249,8 +249,10 @@ jobs:
         pg_dump --version
         pg_restore --version
         got="$(pg_dump --version | grep -oE '[0-9]+' | head -1)"
-        if [ "$got" -lt "${{ matrix.postgres-version }}" ]; then
-          echo "::error::pg_dump $got is older than PostgreSQL ${{ matrix.postgres-version }}; the pg_dump renderer would be skipped"
+        # Via a variable: shellcheck cannot tell that the expansion is numeric.
+        want="${{ matrix.postgres-version }}"
+        if [ "$got" -lt "$want" ]; then
+          echo "::error::pg_dump $got is older than PostgreSQL $want; the pg_dump renderer would be skipped"
           exit 1
         fi
 
@@ -601,8 +603,10 @@ jobs:
         pg_dump --version
         pg_restore --version
         got="$(pg_dump --version | grep -oE '[0-9]+' | head -1)"
-        if [ "$got" -lt "${{ matrix.postgres-version }}" ]; then
-          echo "::error::pg_dump $got is older than PostgreSQL ${{ matrix.postgres-version }}; the pg_dump renderer would be skipped"
+        # Via a variable: shellcheck cannot tell that the expansion is numeric.
+        want="${{ matrix.postgres-version }}"
+        if [ "$got" -lt "$want" ]; then
+          echo "::error::pg_dump $got is older than PostgreSQL $want; the pg_dump renderer would be skipped"
           exit 1
         fi
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -234,8 +234,25 @@ jobs:
           | sudo tee /etc/apt/sources.list.d/pgdg.list > /dev/null
         sudo apt-get update -qq
         sudo apt-get install -y --no-install-recommends postgresql-client-${{ matrix.postgres-version }}
+
+        # /usr/bin/pg_dump is Debian's pg_wrapper, which chooses a version of
+        # its own regardless of what was just installed — on these runners it
+        # resolved to 16 even with postgresql-client-18 present. Against a
+        # newer server the version guard then declines and the renderer under
+        # test never runs, while the job stays green. Point at the binaries
+        # directly instead.
+        echo "/usr/lib/postgresql/${{ matrix.postgres-version }}/bin" >> "$GITHUB_PATH"
+
+    - name: Verify pg_dump matches the server
+      run: |
+        set -euo pipefail
         pg_dump --version
         pg_restore --version
+        got="$(pg_dump --version | grep -oE '[0-9]+' | head -1)"
+        if [ "$got" -lt "${{ matrix.postgres-version }}" ]; then
+          echo "::error::pg_dump $got is older than PostgreSQL ${{ matrix.postgres-version }}; the pg_dump renderer would be skipped"
+          exit 1
+        fi
 
     - name: Run PostgreSQL e2e tests
       run: ./scripts/run-tests.sh --postgres 127.0.0.1
@@ -569,8 +586,25 @@ jobs:
           | sudo tee /etc/apt/sources.list.d/pgdg.list > /dev/null
         sudo apt-get update -qq
         sudo apt-get install -y --no-install-recommends postgresql-client-${{ matrix.postgres-version }}
+
+        # /usr/bin/pg_dump is Debian's pg_wrapper, which chooses a version of
+        # its own regardless of what was just installed — on these runners it
+        # resolved to 16 even with postgresql-client-18 present. Against a
+        # newer server the version guard then declines and the renderer under
+        # test never runs, while the job stays green. Point at the binaries
+        # directly instead.
+        echo "/usr/lib/postgresql/${{ matrix.postgres-version }}/bin" >> "$GITHUB_PATH"
+
+    - name: Verify pg_dump matches the server
+      run: |
+        set -euo pipefail
         pg_dump --version
         pg_restore --version
+        got="$(pg_dump --version | grep -oE '[0-9]+' | head -1)"
+        if [ "$got" -lt "${{ matrix.postgres-version }}" ]; then
+          echo "::error::pg_dump $got is older than PostgreSQL ${{ matrix.postgres-version }}; the pg_dump renderer would be skipped"
+          exit 1
+        fi
 
     # The schema fingerprint and the DDL corpus are shared with SupaForge and
     # published to npm. DBDiff is a Composer project and uses node for nothing

--- a/src/DB/Support/PgDumpRenderer.php
+++ b/src/DB/Support/PgDumpRenderer.php
@@ -39,7 +39,13 @@ use Illuminate\Database\Connection;
  */
 final class PgDumpRenderer
 {
-    /** Cached archive path per connection, so one run dumps each database once. */
+    /**
+     * Cached archive path per connection, so one run dumps each database once.
+     *
+     * The archive is a snapshot taken on first use. That is what a diff wants —
+     * every object rendered from one consistent view — but it does mean an
+     * object created after that point is invisible until reset() is called.
+     */
     private static array $archives = [];
 
     /** Cached table of contents per archive. */

--- a/tests/PgDumpRendererPostgresTest.php
+++ b/tests/PgDumpRendererPostgresTest.php
@@ -35,6 +35,7 @@ class PgDumpRendererPostgresTest extends TestCase
             $this->markTestSkipped('DB_HOST_POSTGRES not set.');
         }
         if (!self::commandExists('pg_dump') || !self::commandExists('pg_restore')) {
+            // Legitimately absent: the renderer steps aside and so do these.
             $this->markTestSkipped('pg_dump/pg_restore not on PATH.');
         }
 
@@ -60,6 +61,22 @@ class PgDumpRendererPostgresTest extends TestCase
         $this->capsule = null;
         $this->connection = $this->connect($host, $port, $user, $pass, $this->database);
         $this->adapter = new PostgresAdapter();
+        PgDumpRenderer::reset();
+
+        // Present but unusable is a misconfiguration, not a reason to skip. On
+        // CI, Debian's pg_wrapper resolved /usr/bin/pg_dump to 16 even with
+        // postgresql-client-18 installed, so against newer servers the guard
+        // declined and every case below silently ran on the built-in renderer
+        // — passing, because the two now agree on collation and identity.
+        $reason = PgDumpRenderer::unavailableReason($this->connection);
+        if ($reason !== null) {
+            $this->fail("pg_dump is installed but unusable, so this suite would test the wrong renderer: $reason");
+        }
+
+        // That check dumps the database to find out, and the archive is cached.
+        // Each case creates its table afterwards, so the cache has to go or the
+        // renderer would look for tables in a snapshot taken before they
+        // existed — and silently fall back.
         PgDumpRenderer::reset();
     }
 
@@ -109,6 +126,20 @@ class PgDumpRendererPostgresTest extends TestCase
         return proc_close($process) === 0;
     }
 
+    /**
+     * Assert the DDL under test actually came from pg_dump.
+     *
+     * The built-in renderer now emits collations and identity options too, so
+     * an assertion on those alone passes either way and proves nothing about
+     * this path.
+     */
+    private function assertCameFromPgDump(string $ddl): void
+    {
+        $this->assertTrue(PgDumpRenderer::wasUsed(), 'DDL did not come from pg_dump');
+        // pg_dump schema-qualifies; the built-in renderer emits bare quoted names.
+        $this->assertStringContainsString('public.', $ddl);
+    }
+
     /** Collation decides sort order, and the built-in renderer dropped it. */
     public function testRendersAnExplicitCollation(): void
     {
@@ -116,6 +147,7 @@ class PgDumpRendererPostgresTest extends TestCase
 
         $ddl = $this->adapter->getCreateStatement($this->connection, 't');
 
+        $this->assertCameFromPgDump($ddl);
         $this->assertStringContainsString('COLLATE', $ddl);
         $this->assertStringContainsString('"C"', $ddl);
     }
@@ -133,6 +165,7 @@ class PgDumpRendererPostgresTest extends TestCase
 
         $ddl = $this->adapter->getCreateStatement($this->connection, 't');
 
+        $this->assertCameFromPgDump($ddl);
         $this->assertStringContainsString('GENERATED ALWAYS AS IDENTITY', $ddl);
         $this->assertStringContainsString('INCREMENT BY 10', $ddl);
         $this->assertStringContainsString('START WITH 100', $ddl);
@@ -146,6 +179,7 @@ class PgDumpRendererPostgresTest extends TestCase
 
         $ddl = $this->adapter->getCreateStatement($this->connection, 't');
 
+        $this->assertCameFromPgDump($ddl);
         $this->assertStringContainsString('CREATE INDEX t_b_idx', $ddl);
     }
 


### PR DESCRIPTION
CI was green while exercising the **wrong renderer**, and the tests could not tell.

## What was happening

Debian's `/usr/bin/pg_dump` is `pg_wrapper`, which picks a version of its own regardless of what you install. On the runners it resolved to **16** even in jobs that had just installed `postgresql-client-18`:

```
Setting up postgresql-client-18
...
pg_dump (PostgreSQL) 16.15
```

So against PostgreSQL 17 and 18 the version guard **correctly declined** and every case ran on the built-in renderer instead — and passed, because #199 had already taught that renderer collations and identity options. The assertions were true of both paths, so they proved nothing about this one.

## Three changes

1. **Jobs use the real binaries**, putting `/usr/lib/postgresql/<version>/bin` ahead of the wrapper, and a following step **fails outright** if `pg_dump` is older than the server rather than letting the suite quietly test something else.
2. **Present-but-unusable now fails**, rather than skipping. Absent is a legitimate skip — the renderer steps aside too — but installed-and-declined is a misconfiguration worth hearing about.
3. **Every case asserts the DDL actually came from pg_dump**, by checking the renderer recorded itself *and* that the output is schema-qualified, which the built-in renderer never produces.

## Verified in both directions

| condition | before | after |
| --- | --- | --- |
| usable pg_dump | 8 pass, 16 assertions | **8 pass, 22 assertions** |
| stub reporting 9.6 | **8 pass** ← the bug | **8 fail** |

That second row is the point: the suite used to pass while testing the wrong thing.

## A cache subtlety this surfaced

The availability probe dumps the database, and the archive is cached — so a table created *afterwards* is invisible until `reset()`. That is correct for a diff, which wants one consistent view of the schema, but it is easy to trip over. Now documented, and the suite resets between cases.

Full suite unchanged: Unit 753, Postgres 55, MySQL 17, SQLite 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)