### PR TITLE
fix(release): restore libpq so the Windows binary has a Postgres driver

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -242,6 +242,31 @@ jobs:
           .\spc.exe doctor --auto-fix
           New-Item -ItemType Directory -Force -Path source | Out-Null
           .\spc.exe download "php-src,micro,${{ env.SPC_EXTENSIONS }},${{ env.SPC_WINDOWS_LIBS }}" --with-php="${{ env.SPC_PHP_VERSION }}"
+
+          # Work around an SPC bug that silently produces a binary without
+          # pdo_pgsql.
+          #
+          # SPC extracts zips with unzipWithStrip(), which drops the archive's
+          # single top-level directory — here `pgsql`. Its postgresql_win
+          # builder then copies from `<source>\pgsql\lib\libpq.lib`, the level
+          # that was just stripped. Every copy fails as a PHP *warning*, so the
+          # build carries on and produces a Postgres tool with no Postgres
+          # driver, which `--version` reports as perfectly healthy.
+          #
+          # Re-create the expected level as junctions rather than copies: no
+          # duplication, and it disappears if SPC fixes the path.
+          $pg = "source\postgresql-win"
+          if ((Test-Path "$pg\lib") -and -not (Test-Path "$pg\pgsql")) {
+            Write-Output "Re-creating the pgsql/ level SPC stripped but still expects"
+            New-Item -ItemType Directory -Force -Path "$pg\pgsql" | Out-Null
+            New-Item -ItemType Junction -Path "$pg\pgsql\lib"     -Target (Resolve-Path "$pg\lib")     | Out-Null
+            New-Item -ItemType Junction -Path "$pg\pgsql\include" -Target (Resolve-Path "$pg\include") | Out-Null
+          }
+          if (-not (Test-Path "$pg\pgsql\lib\libpq.lib")) {
+            Write-Output "::error::libpq.lib not found under $pg\pgsql\lib — pdo_pgsql would be built without it"
+            Get-ChildItem -Path $pg -Depth 1 | Select-Object -ExpandProperty FullName
+            exit 1
+          }
           .\spc.exe build "${{ env.SPC_EXTENSIONS }}" --build-micro --debug --without-micro-ext-test
 
       - name: Combine PHP + PHAR → binary (Windows)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,6 +297,31 @@ jobs:
           # "The system cannot find the path specified."
           New-Item -ItemType Directory -Force -Path source | Out-Null
           .\spc.exe download "php-src,micro,${{ env.SPC_EXTENSIONS }},${{ env.SPC_WINDOWS_LIBS }}" --with-php="${{ env.SPC_PHP_VERSION }}"
+
+          # Work around an SPC bug that silently produces a binary without
+          # pdo_pgsql.
+          #
+          # SPC extracts zips with unzipWithStrip(), which drops the archive's
+          # single top-level directory — here `pgsql`. Its postgresql_win
+          # builder then copies from `<source>\pgsql\lib\libpq.lib`, the level
+          # that was just stripped. Every copy fails as a PHP *warning*, so the
+          # build carries on and produces a Postgres tool with no Postgres
+          # driver, which `--version` reports as perfectly healthy.
+          #
+          # Re-create the expected level as junctions rather than copies: no
+          # duplication, and it disappears if SPC fixes the path.
+          $pg = "source\postgresql-win"
+          if ((Test-Path "$pg\lib") -and -not (Test-Path "$pg\pgsql")) {
+            Write-Output "Re-creating the pgsql/ level SPC stripped but still expects"
+            New-Item -ItemType Directory -Force -Path "$pg\pgsql" | Out-Null
+            New-Item -ItemType Junction -Path "$pg\pgsql\lib"     -Target (Resolve-Path "$pg\lib")     | Out-Null
+            New-Item -ItemType Junction -Path "$pg\pgsql\include" -Target (Resolve-Path "$pg\include") | Out-Null
+          }
+          if (-not (Test-Path "$pg\pgsql\lib\libpq.lib")) {
+            Write-Output "::error::libpq.lib not found under $pg\pgsql\lib — pdo_pgsql would be built without it"
+            Get-ChildItem -Path $pg -Depth 1 | Select-Object -ExpandProperty FullName
+            exit 1
+          }
           # --without-micro-ext-test: SPC auto-pulls the pgsql extension as a
           # dependency of pdo_pgsql, but the standalone pgsql ext fails its
           # runtime sanity check on Windows (extension_loaded('pgsql') → false).


### PR DESCRIPTION
The `3.0.0-rc.10` dry run built a `win32-x64` binary with **no `pdo_pgsql`**. The driver smoke test from #197 caught it:

```
##[error]postgresql driver missing from the binary
```

## Root cause — upstream in static-php-cli 2.8.3

`unzipWithStrip()` drops an archive's single top-level directory. For the EnterpriseDB Windows zip that directory is `pgsql`. Its `postgresql_win` builder then copies from the level it just stripped:

```php
copy($this->source_dir . '\pgsql\lib\libpq.lib', ...);
```

```
copy(...\postgresql-win\pgsql\lib\libpq.lib): Failed to open stream
copy(...\postgresql-win\pgsql\include\libpq-fe.h): Failed to open stream
```

Every copy fails as a PHP **warning**, so the build carries on and produces a Postgres diff tool that cannot reach Postgres — and `--version` reports it as perfectly healthy.

## The fix

Re-create the stripped level as **junctions** after `spc download` — no duplication, and it becomes a no-op the moment SPC fixes the path (it is guarded on `pgsql` not already existing).

A following check then fails the build outright if `libpq.lib` is still missing, and prints the tree. The next person to hit this gets evidence, not a warning buried in 36,000 log lines.

Applied to `release-dry-run.yml` too, so the dry run keeps testing what the release does.

## How this was found

Not by guessing. The dry run failed → the smoke test named the symptom → SPC's `postgresql_win.php` showed the expected path → `unzipWithStrip()` showed the actual one. The fix follows from the evidence rather than preceding it.

Worth noting the sequence: #197's NASM fix made the Windows build *succeed*, which is what allowed it to produce a silently broken binary — and #197's smoke test is what stopped it shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)