### PR TITLE
fix(release): extract postgresql-win before repairing its layout

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -253,8 +253,12 @@ jobs:
           # build carries on and produces a Postgres tool with no Postgres
           # driver, which `--version` reports as perfectly healthy.
           #
-          # Re-create the expected level as junctions rather than copies: no
-          # duplication, and it disappears if SPC fixes the path.
+          # `download` only fetches archives; extraction happens during `build`.
+          # Extracting explicitly first gives somewhere to apply the fix, and
+          # `build` then skips re-extracting because SourceManager honours the
+          # .spc-hash that `extract` leaves behind — so the junctions survive.
+          .\spc.exe extract postgresql-win
+
           $pg = "source\postgresql-win"
           if ((Test-Path "$pg\lib") -and -not (Test-Path "$pg\pgsql")) {
             Write-Output "Re-creating the pgsql/ level SPC stripped but still expects"
@@ -264,9 +268,11 @@ jobs:
           }
           if (-not (Test-Path "$pg\pgsql\lib\libpq.lib")) {
             Write-Output "::error::libpq.lib not found under $pg\pgsql\lib — pdo_pgsql would be built without it"
-            Get-ChildItem -Path $pg -Depth 1 | Select-Object -ExpandProperty FullName
+            if (Test-Path $pg) { Get-ChildItem -Path $pg -Depth 1 | Select-Object -ExpandProperty FullName }
+            else { Write-Output "$pg does not exist" }
             exit 1
           }
+          Write-Output "libpq.lib is in place"
           .\spc.exe build "${{ env.SPC_EXTENSIONS }}" --build-micro --debug --without-micro-ext-test
 
       - name: Combine PHP + PHAR → binary (Windows)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,8 +308,12 @@ jobs:
           # build carries on and produces a Postgres tool with no Postgres
           # driver, which `--version` reports as perfectly healthy.
           #
-          # Re-create the expected level as junctions rather than copies: no
-          # duplication, and it disappears if SPC fixes the path.
+          # `download` only fetches archives; extraction happens during `build`.
+          # Extracting explicitly first gives somewhere to apply the fix, and
+          # `build` then skips re-extracting because SourceManager honours the
+          # .spc-hash that `extract` leaves behind — so the junctions survive.
+          .\spc.exe extract postgresql-win
+
           $pg = "source\postgresql-win"
           if ((Test-Path "$pg\lib") -and -not (Test-Path "$pg\pgsql")) {
             Write-Output "Re-creating the pgsql/ level SPC stripped but still expects"
@@ -319,9 +323,11 @@ jobs:
           }
           if (-not (Test-Path "$pg\pgsql\lib\libpq.lib")) {
             Write-Output "::error::libpq.lib not found under $pg\pgsql\lib — pdo_pgsql would be built without it"
-            Get-ChildItem -Path $pg -Depth 1 | Select-Object -ExpandProperty FullName
+            if (Test-Path $pg) { Get-ChildItem -Path $pg -Depth 1 | Select-Object -ExpandProperty FullName }
+            else { Write-Output "$pg does not exist" }
             exit 1
           }
+          Write-Output "libpq.lib is in place"
           # --without-micro-ext-test: SPC auto-pulls the pgsql extension as a
           # dependency of pdo_pgsql, but the standalone pgsql ext fails its
           # runtime sanity check on Windows (extension_loaded('pgsql') → false).


### PR DESCRIPTION
Follow-up to #203, which fixed the right thing in the wrong place.

## What happened

#203 applied the layout repair straight after `spc download` — but **`download` only fetches archives**. Extraction into `source/` happens during `build`. So the repair never ran, and the guard fired on a directory that did not exist yet:

```
::error::libpq.lib not found under source\postgresql-win\pgsql\lib
```

That is the guard working correctly. It failed the build rather than letting a driverless binary through, which is what #197's smoke test would otherwise have caught one step later.

## The fix

Run `spc extract postgresql-win` first, so there is something to repair.

The later `build` does not undo it. `SourceManager::initSource` skips extraction when the source directory exists and its `.spc-hash` matches — and that hash is over the **downloaded archive**, so adding a directory alongside does not invalidate it:

```php
if (file_exists("{$check}/.spc-hash") && FileSystem::readFile("{$check}/.spc-hash") === $hash) {
    logger()->debug("Source [{$source}] already extracted in {$check}, skip !");
    continue;
}
```

Everything else is unchanged: junctions rather than copies, so the workaround costs nothing and becomes a no-op if SPC fixes the stripped path, and the build still fails loudly with a directory listing if `libpq.lib` is missing.

## Status of the dry run

`3.0.0-rc.10` currently builds **8 of 9 targets** cleanly — PHAR, both macOS, all four Linux variants, and the npm dry-run publish. `win32-x64` is the only one outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)